### PR TITLE
Fix batch variable generation

### DIFF
--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -12,30 +12,33 @@
 
 """Quadratic Program."""
 
-from typing import cast, List, Union, Dict, Optional, Tuple
 import logging
+import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from enum import Enum
 from math import fsum, isclose
-import warnings
-import numpy as np
-from numpy import (ndarray, zeros, bool as nbool)
-from scipy.sparse import spmatrix
+from typing import Dict, List, Optional, Tuple, Union, cast
 
-from docplex.mp.constr import (LinearConstraint as DocplexLinearConstraint,
-                               QuadraticConstraint as DocplexQuadraticConstraint,
-                               NotEqualConstraint)
+import numpy as np
+from docplex.mp.constr import LinearConstraint as DocplexLinearConstraint
+from docplex.mp.constr import NotEqualConstraint
+from docplex.mp.constr import QuadraticConstraint as DocplexQuadraticConstraint
 from docplex.mp.linear import Var
 from docplex.mp.model import Model
 from docplex.mp.model_reader import ModelReader
 from docplex.mp.quad import QuadExpr
-from docplex.mp.vartype import ContinuousVarType, BinaryVarType, IntegerVarType
+from docplex.mp.vartype import BinaryVarType, ContinuousVarType, IntegerVarType
+from numpy import bool as nbool
+from numpy import ndarray, zeros
+from scipy.sparse import spmatrix
 
 from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit.opflow import (I, ListOp, OperatorBase, PauliOp, SummedOp,
-                           PauliSumOp)
+from qiskit.opflow import I, ListOp, OperatorBase, PauliOp, PauliSumOp, SummedOp
 from qiskit.quantum_info import Pauli
+
+from ..exceptions import QiskitOptimizationError
+from ..infinity import INFINITY
 from .constraint import Constraint, ConstraintSense
 from .linear_constraint import LinearConstraint
 from .linear_expression import LinearExpression
@@ -43,8 +46,6 @@ from .quadratic_constraint import QuadraticConstraint
 from .quadratic_expression import QuadraticExpression
 from .quadratic_objective import QuadraticObjective
 from .variable import Variable, VarType
-from ..exceptions import QiskitOptimizationError
-from ..infinity import INFINITY
 
 logger = logging.getLogger(__name__)
 
@@ -150,81 +151,69 @@ class QuadraticProgram:
         return self._variables_index
 
     def _add_variable(self,
-                      lowerbound: Union[float, int] = 0,
-                      upperbound: Union[float, int] = INFINITY,
-                      vartype: VarType = VarType.CONTINUOUS,
-                      name: Optional[str] = None) -> Variable:
-        return self._add_variables(lowerbound, upperbound, vartype, name)[1][0]
+                      lowerbound: Union[float, int],
+                      upperbound: Union[float, int],
+                      vartype: VarType,
+                      name: Optional[str]) -> Variable:
+        if name is None:
+            name = 'x'
+            key_format = '{}'
+        else:
+            key_format = ''
+        return self._add_variables(1, lowerbound, upperbound, vartype, name, key_format)[1][0]
 
     def _add_variables(self,
-                       lowerbound: Union[float, int] = 0,
-                       upperbound: Union[float, int] = INFINITY,
-                       vartype: VarType = VarType.CONTINUOUS,
-                       name: Optional[str] = None,
-                       key_format: Optional[str] = None,
-                       keys: Union[int, Sequence] = 1) -> Tuple[List[str], List[Variable]]:
+                       keys: Union[int, Sequence],
+                       lowerbound: Union[float, int],
+                       upperbound: Union[float, int],
+                       vartype: VarType,
+                       name: Optional[str],
+                       key_format: str) -> Tuple[List[str], List[Variable]]:
         if isinstance(keys, int) and keys < 1:
             raise QiskitOptimizationError(
                 "Cannot create non-positive number of variables: {}".format(keys))
-        if not name and key_format:
+        if name is None:
             name = 'x'
-        if name and not key_format:
-            if isinstance(keys, int) and keys > 1 or isinstance(keys, Sequence) and len(keys) > 0:
-                key_format = '{}'
-            else:
-                key_format = ''
-                if name in self._variables_index:
-                    raise QiskitOptimizationError("Variable name already exists: {}".format(name))
-        if not name and not key_format:
-            name = 'x'
-            key_format = '{}'
+        if key_format == '' and name in self._variables_index:
+            raise QiskitOptimizationError("Variable name already exists: {}".format(name))
         if '{{}}' in key_format:
             raise QiskitOptimizationError(
                 "Formatter cannot contain nested substitutions: {}".format(key_format))
-        substitution_count = key_format.count('{}')
-        if substitution_count > 1:
+        if key_format.count('{}') > 1:
             raise QiskitOptimizationError(
                 "Formatter cannot contain more than one substitution: {}".format(key_format))
 
+        def _find_name(name, key_format, k):
+            while name + key_format.format(k) in self._variables_index:
+                k += 1
+            return name + key_format.format(k), k + 1
+
         names = []
         variables = []
-        if isinstance(keys, Sequence):
-            for key in keys:
-                indexed_name = name + key_format.format(str(key))
-                if indexed_name in self._variables_index:
-                    raise QiskitOptimizationError(
-                        "Variable name already exists: {}".format(indexed_name))
-                names.append(indexed_name)
-                variables.append(
-                    self._create_var_update_index(lowerbound, upperbound, vartype, indexed_name))
-        else:
-            k = self.get_num_vars()
-            for _ in range(keys):
-                while name + key_format.format(k) in self._variables_index:
-                    k += 1
-                indexed_name = name + key_format.format(k)
-                names.append(indexed_name)
-                variables.append(
-                    self._create_var_update_index(lowerbound, upperbound, vartype, indexed_name))
+        k = self.get_num_vars()
+        lst = keys if isinstance(keys, Sequence) else range(keys)
+        for key in lst:
+            if isinstance(keys, Sequence):
+                indexed_name = name + key_format.format(key)
+            else:
+                indexed_name, k = _find_name(name, key_format, k)
+            if indexed_name in self._variables_index:
+                raise QiskitOptimizationError(
+                    "Variable name already exists: {}".format(indexed_name))
+            names.append(indexed_name)
+            self._variables_index[indexed_name] = self.get_num_vars()
+            variable = Variable(self, indexed_name, lowerbound, upperbound, vartype)
+            self._variables.append(variable)
+            variables.append(variable)
         return names, variables
 
-    def _create_var_update_index(self,
-                                 lowerbound: Union[float, int],
-                                 upperbound: Union[float, int],
-                                 vartype: VarType,
-                                 name: str) -> Variable:
-        self.variables_index[name] = len(self.variables)
-        variable = Variable(self, name, lowerbound, upperbound, vartype)
-        self.variables.append(variable)
-        return variable
-
     def _var_dict(self,
-                  lowerbound: Union[float, int] = 0,
-                  upperbound: Union[float, int] = INFINITY,
-                  vartype: VarType = VarType.CONTINUOUS,
-                  name: Optional[str] = None,
-                  key_format: Optional[str] = None,
-                  keys: Union[int, Sequence] = 1) -> Dict[str, Variable]:
+                  keys: Union[int, Sequence],
+                  lowerbound: Union[float, int],
+                  upperbound: Union[float, int],
+                  vartype: VarType,
+                  name: Optional[str],
+                  key_format: str) -> Dict[str, Variable]:
         """
         Adds a positive number of variables to the variable list and index and returns a
         dictionary mapping the variable names to their instances. If 'key_format' is present,
@@ -251,15 +240,15 @@ class QuadraticProgram:
                                      nested substitution.
         """
         return dict(
-            zip(*self._add_variables(lowerbound, upperbound, vartype, name, key_format, keys)))
+            zip(*self._add_variables(keys, lowerbound, upperbound, vartype, name, key_format)))
 
     def _var_list(self,
-                  lowerbound: Union[float, int] = 0,
-                  upperbound: Union[float, int] = INFINITY,
-                  vartype: VarType = VarType.CONTINUOUS,
-                  name: Optional[str] = None,
-                  key_format: Optional[str] = None,
-                  keys: Union[int, Sequence] = 1) -> List[Variable]:
+                  keys: Union[int, Sequence],
+                  lowerbound: Union[float, int],
+                  upperbound: Union[float, int],
+                  vartype: VarType,
+                  name: Optional[str],
+                  key_format: str) -> List[Variable]:
         """
         Adds a positive number of variables to the variable list and index and returns a
         list of variable instances.
@@ -283,7 +272,7 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._add_variables(lowerbound, upperbound, vartype, name, key_format, keys)[1]
+        return self._add_variables(keys, lowerbound, upperbound, vartype, name, key_format)[1]
 
     def continuous_var(self,
                        lowerbound: Union[float, int] = 0,
@@ -305,11 +294,11 @@ class QuadraticProgram:
         return self._add_variable(lowerbound, upperbound, Variable.Type.CONTINUOUS, name)
 
     def continuous_var_dict(self,
+                            keys: Union[int, Sequence],
                             lowerbound: Union[float, int] = 0,
                             upperbound: Union[float, int] = INFINITY,
                             name: Optional[str] = None,
-                            key_format: Optional[str] = None,
-                            keys: Union[int, Sequence] = 1) -> Dict[str, Variable]:
+                            key_format: str = '{}') -> Dict[str, Variable]:
         """
         Uses 'var_dict' to construct a dictionary of continuous variables
 
@@ -331,15 +320,15 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._var_dict(lowerbound, upperbound, Variable.Type.CONTINUOUS, name, key_format,
-                              keys)
+        return self._var_dict(keys, lowerbound, upperbound, Variable.Type.CONTINUOUS, name,
+                              key_format)
 
     def continuous_var_list(self,
+                            keys: Union[int, Sequence],
                             lowerbound: Union[float, int] = 0,
                             upperbound: Union[float, int] = INFINITY,
                             name: Optional[str] = None,
-                            key_format: Optional[str] = None,
-                            keys: Union[int, Sequence] = 1) -> List[Variable]:
+                            key_format: str = '{}') -> List[Variable]:
         """
         Uses 'var_list' to construct a list of continuous variables
 
@@ -361,8 +350,8 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._var_list(lowerbound, upperbound, Variable.Type.CONTINUOUS,
-                              name, key_format, keys)
+        return self._var_list(keys, lowerbound, upperbound, Variable.Type.CONTINUOUS,
+                              name, key_format)
 
     def binary_var(self, name: Optional[str] = None) -> Variable:
         """Adds a binary variable to the quadratic program.
@@ -379,9 +368,9 @@ class QuadraticProgram:
         return self._add_variable(0, 1, Variable.Type.BINARY, name)
 
     def binary_var_dict(self,
+                        keys: Union[int, Sequence],
                         name: Optional[str] = None,
-                        key_format: Optional[str] = None,
-                        keys: Union[int, Sequence] = 1) -> Dict[str, Variable]:
+                        key_format: str = '{}') -> Dict[str, Variable]:
         """
         Uses 'var_dict' to construct a dictionary of binary variables
 
@@ -401,12 +390,12 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._var_dict(0, 1, Variable.Type.BINARY, name, key_format, keys)
+        return self._var_dict(keys, 0, 1, Variable.Type.BINARY, name, key_format)
 
     def binary_var_list(self,
+                        keys: Union[int, Sequence],
                         name: Optional[str] = None,
-                        key_format: Optional[str] = None,
-                        keys: Union[int, Sequence] = 1) -> List[Variable]:
+                        key_format: str = '{}') -> List[Variable]:
         """
         Uses 'var_list' to construct a list of binary variables
 
@@ -426,7 +415,7 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._var_list(0, 1, Variable.Type.BINARY, name, key_format, keys)
+        return self._var_list(keys, 0, 1, Variable.Type.BINARY, name, key_format)
 
     def integer_var(self,
                     lowerbound: Union[float, int] = 0,
@@ -448,11 +437,11 @@ class QuadraticProgram:
         return self._add_variable(lowerbound, upperbound, Variable.Type.INTEGER, name)
 
     def integer_var_dict(self,
+                         keys: Union[int, Sequence],
                          lowerbound: Union[float, int] = 0,
                          upperbound: Union[float, int] = INFINITY,
                          name: Optional[str] = None,
-                         key_format: Optional[str] = None,
-                         keys: Union[int, Sequence] = 1) -> Dict[str, Variable]:
+                         key_format: str = '{}') -> Dict[str, Variable]:
         """
         Uses 'var_dict' to construct a dictionary of integer variables
 
@@ -474,14 +463,14 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._var_dict(lowerbound, upperbound, Variable.Type.INTEGER, name, key_format, keys)
+        return self._var_dict(keys, lowerbound, upperbound, Variable.Type.INTEGER, name, key_format)
 
     def integer_var_list(self,
+                         keys: Union[int, Sequence],
                          lowerbound: Union[float, int] = 0,
                          upperbound: Union[float, int] = INFINITY,
                          name: Optional[str] = None,
-                         key_format: Optional[str] = None,
-                         keys: Union[int, Sequence] = 1) -> List[Variable]:
+                         key_format: str = '{}') -> List[Variable]:
         """
         Uses 'var_list' to construct a dictionary of integer variables
 
@@ -503,7 +492,7 @@ class QuadraticProgram:
             QiskitOptimizationError: if `key_format` has more than one substitution or a
                                      nested substitution.
         """
-        return self._var_list(lowerbound, upperbound, Variable.Type.INTEGER, name, key_format, keys)
+        return self._var_list(keys, lowerbound, upperbound, Variable.Type.INTEGER, name, key_format)
 
     def get_variable(self, i: Union[int, str]) -> Variable:
         """Returns a variable for a given name or index.
@@ -1390,8 +1379,8 @@ class QuadraticProgram:
         # if input `x` is not the same len as the total vars, raise an error
         if len(x) != self.get_num_vars():
             raise QiskitOptimizationError(
-                'The size of solution `x`: {}, does not match the number of problem variables: {}'
-                .format(len(x), self.get_num_vars()))
+                'The size of solution `x`: {}, does not match the number of problem variables: '
+                '{}'.format(len(x), self.get_num_vars()))
 
         # check whether the input satisfy the bounds of the problem
         violated_variables = []  # type: List[Variable]

--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -174,8 +174,6 @@ class QuadraticProgram:
                 "Cannot create non-positive number of variables: {}".format(keys))
         if name is None:
             name = 'x'
-        if key_format == '' and name in self._variables_index:
-            raise QiskitOptimizationError("Variable name already exists: {}".format(name))
         if '{{}}' in key_format:
             raise QiskitOptimizationError(
                 "Formatter cannot contain nested substitutions: {}".format(key_format))
@@ -184,9 +182,18 @@ class QuadraticProgram:
                 "Formatter cannot contain more than one substitution: {}".format(key_format))
 
         def _find_name(name, key_format, k):
-            while name + key_format.format(k) in self._variables_index:
-                k += 1
-            return name + key_format.format(k), k + 1
+            prev = None
+            while True:
+                new_name = name + key_format.format(k)
+                if new_name == prev:
+                    raise QiskitOptimizationError(
+                        "Variable name already exists: {}".format(new_name))
+                if new_name in self._variables_index:
+                    k += 1
+                    prev = new_name
+                else:
+                    break
+            return new_name, k + 1
 
         names = []
         variables = []

--- a/test/test_quadratic_program.py
+++ b/test/test_quadratic_program.py
@@ -17,11 +17,11 @@ import unittest
 from os import path
 from test.optimization_test_case import QiskitOptimizationTestCase
 
-from docplex.mp.model import Model, DOcplexException
+from docplex.mp.model import DOcplexException, Model
 
 from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit_optimization import QuadraticProgram, QiskitOptimizationError, INFINITY
-from qiskit_optimization.problems import Variable, Constraint, QuadraticObjective
+from qiskit_optimization import INFINITY, QiskitOptimizationError, QuadraticProgram
+from qiskit_optimization.problems import Constraint, QuadraticObjective, Variable, VarType
 
 
 class TestQuadraticProgram(QiskitOptimizationTestCase):
@@ -77,54 +77,52 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         """test {binary,integer,continuous}_var_dict"""
         q_p = QuadraticProgram()
 
-        c_count = 0
-        b_count = 0
-        i_count = 0
-
-        def verify_counts():
-            self.assertEqual(q_p.get_num_vars(), c_count + b_count + i_count)
-            self.assertEqual(q_p.get_num_continuous_vars(), c_count)
-            self.assertEqual(q_p.get_num_binary_vars(), b_count)
-            self.assertEqual(q_p.get_num_integer_vars(), i_count)
-
-        def check_dict(var_dict, offset):
-            verify_counts()
-            variables = var_dict.values()
-            for i, x in enumerate(variables):
-                y = q_p.get_variable(i + offset)
-                z = q_p.get_variable(x.name)
-                self.assert_equal(x, y)
-                self.assert_equal(x, z)
-
         d_0 = q_p.continuous_var_dict(name='a', key_format='_{}', keys=3)
-        c_count += 3
-        check_dict(d_0, 0)
+        self.assertSetEqual(set(d_0.keys()), {'a_0', 'a_1', 'a_2'})
+        self.assertSetEqual({var.name for var in q_p.variables}, {'a_0', 'a_1', 'a_2'})
+        for var in q_p.variables:
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, INFINITY)
+            self.assertEqual(var.vartype, VarType.CONTINUOUS)
+            self.assertTupleEqual(var.as_tuple(), d_0[var.name].as_tuple())
 
         d_1 = q_p.binary_var_dict(name='b', keys=5)
-        b_count += 5
-        check_dict(d_1, len(d_0))
+        self.assertSetEqual(set(d_1.keys()), {'b3', 'b4', 'b5', 'b6', 'b7'})
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7'})
+        for var in q_p.variables[-5:]:
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, 1)
+            self.assertEqual(var.vartype, VarType.BINARY)
+            self.assertTupleEqual(var.as_tuple(), d_1[var.name].as_tuple())
 
-        d_2 = q_p.integer_var_dict(key_format='_{}', keys=7, lowerbound=-4, upperbound=10)
-        i_count += 7
-        check_dict(d_2, len(d_0) + len(d_1))
+        d_2 = q_p.integer_var_dict(keys=1, key_format='-{}', lowerbound=-4, upperbound=10)
+        self.assertSetEqual(set(d_2.keys()), {'x-8'})
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8'})
+        for var in q_p.variables[-1:]:
+            self.assertAlmostEqual(var.lowerbound, -4)
+            self.assertAlmostEqual(var.upperbound, 10)
+            self.assertEqual(var.vartype, VarType.INTEGER)
+            self.assertTupleEqual(var.as_tuple(), d_2[var.name].as_tuple())
 
-        d_3 = q_p.continuous_var_dict(name='a', key_format='_{}', keys=3)
-        c_count += 3
-        check_dict(d_3, len(d_0) + len(d_1) + len(d_2))
-
-        d_4 = q_p.continuous_var_dict(name='c', keys=range(3))
-        c_count += 3
-        check_dict(d_4, len(d_0) + len(d_1) + len(d_2) + len(d_3))
-
-        with self.assertRaises(QiskitOptimizationError):
-            q_p.binary_var_dict(name='c0')
+        d_3 = q_p.binary_var_dict(name='c', keys=range(3))
+        self.assertSetEqual(set(d_3.keys()), {'c0', 'c1', 'c2'})
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8',
+                             'c0', 'c1', 'c2'})
+        for var in q_p.variables[-3:]:
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, 1)
+            self.assertEqual(var.vartype, VarType.BINARY)
+            self.assertTupleEqual(var.as_tuple(), d_3[var.name].as_tuple())
 
         with self.assertRaises(QiskitOptimizationError):
             q_p.binary_var_dict(name='c', keys=range(3))
 
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
-            q_p.binary_var_dict(key_format='{}{}')
+            q_p.binary_var_dict(keys=1, key_format='{}{}')
 
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
@@ -132,64 +130,62 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
 
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
-            q_p.binary_var_dict(name='a')
-            q_p.binary_var_dict(name='a')
-
-        with self.assertRaises(QiskitOptimizationError):
-            q_p = QuadraticProgram()
-            q_p.binary_var_dict(key_format='_{{}}')
+            q_p.binary_var_dict(keys=1, key_format='_{{}}')
 
     def test_var_list(self):
         """test {binary,integer,continuous}_var_list"""
         q_p = QuadraticProgram()
 
-        c_count = 0
-        b_count = 0
-        i_count = 0
-
-        def verify_counts():
-            self.assertEqual(q_p.get_num_vars(), c_count + b_count + i_count)
-            self.assertEqual(q_p.get_num_continuous_vars(), c_count)
-            self.assertEqual(q_p.get_num_binary_vars(), b_count)
-            self.assertEqual(q_p.get_num_integer_vars(), i_count)
-
-        def check_list(var_list, offset):
-            verify_counts()
-            for i, x in enumerate(var_list):
-                y = q_p.get_variable(i + offset)
-                z = q_p.get_variable(x.name)
-                self.assert_equal(x, y)
-                self.assert_equal(x, z)
-
         d_0 = q_p.continuous_var_list(name='a', key_format='_{}', keys=3)
-        c_count += 3
-        check_list(d_0, 0)
+        names = ['a_0', 'a_1', 'a_2']
+        self.assertSetEqual({var.name for var in q_p.variables}, {'a_0', 'a_1', 'a_2'})
+        for i, var in enumerate(q_p.variables):
+            self.assertEqual(var.name, names[i])
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, INFINITY)
+            self.assertEqual(var.vartype, VarType.CONTINUOUS)
+            self.assertTupleEqual(var.as_tuple(), d_0[i].as_tuple())
 
         d_1 = q_p.binary_var_list(name='b', keys=5)
-        b_count += 5
-        check_list(d_1, len(d_0))
+        names = ['b3', 'b4', 'b5', 'b6', 'b7']
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7'})
+        for i, var in enumerate(q_p.variables[-5:]):
+            self.assertEqual(var.name, names[i])
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, 1)
+            self.assertEqual(var.vartype, VarType.BINARY)
+            self.assertTupleEqual(var.as_tuple(), d_1[i].as_tuple())
 
-        d_2 = q_p.integer_var_list(key_format='_{}', keys=7, lowerbound=-4, upperbound=10)
-        i_count += 7
-        check_list(d_2, len(d_0) + len(d_1))
+        d_2 = q_p.integer_var_list(keys=1, key_format='-{}', lowerbound=-4, upperbound=10)
+        names = ['x-8']
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8'})
+        for i, var in enumerate(q_p.variables[-1:]):
+            self.assertEqual(var.name, names[i])
+            self.assertAlmostEqual(var.lowerbound, -4)
+            self.assertAlmostEqual(var.upperbound, 10)
+            self.assertEqual(var.vartype, VarType.INTEGER)
+            self.assertTupleEqual(var.as_tuple(), d_2[i].as_tuple())
 
-        d_3 = q_p.continuous_var_list(name='a', key_format='_{}', keys=3)
-        c_count += 3
-        check_list(d_3, len(d_0) + len(d_1) + len(d_2))
-
-        d_4 = q_p.continuous_var_list(name='c', keys=range(3))
-        c_count += 3
-        check_list(d_4, len(d_0) + len(d_1) + len(d_2) + len(d_3))
-
-        with self.assertRaises(QiskitOptimizationError):
-            q_p.binary_var_list(name='c0')
+        d_3 = q_p.binary_var_list(name='c', keys=range(3))
+        names = ['c0', 'c1', 'c2']
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8',
+                             'c0', 'c1', 'c2'})
+        for i, var in enumerate(q_p.variables[-3:]):
+            self.assertEqual(var.name, names[i])
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, 1)
+            self.assertEqual(var.vartype, VarType.BINARY)
+            self.assertTupleEqual(var.as_tuple(), d_3[i].as_tuple())
 
         with self.assertRaises(QiskitOptimizationError):
             q_p.binary_var_list(name='c', keys=range(3))
 
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
-            q_p.binary_var_list(key_format='{}{}')
+            q_p.binary_var_list(keys=1, key_format='{}{}')
 
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
@@ -197,12 +193,7 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
 
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
-            q_p.binary_var_list(name='a')
-            q_p.binary_var_list(name='a')
-
-        with self.assertRaises(QiskitOptimizationError):
-            q_p = QuadraticProgram()
-            q_p.binary_var_list(key_format='_{{}}')
+            q_p.binary_var_list(keys=1, key_format='_{{}}')
 
     def test_variables_handling(self):
         """ test add variables """
@@ -703,13 +694,13 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         x = mod.binary_var()
         y = mod.continuous_var()
         z = mod.integer_var()
-        mod.minimize(x+y+z + x*y + y*z + x*z)
-        mod.add_constraint(x+y == z)  # linear EQ
-        mod.add_constraint(x+y >= z)  # linear GE
-        mod.add_constraint(x+y <= z)  # linear LE
-        mod.add_constraint(x*y == z)  # quadratic EQ
-        mod.add_constraint(x*y >= z)  # quadratic GE
-        mod.add_constraint(x*y <= z)  # quadratic LE
+        mod.minimize(x + y + z + x * y + y * z + x * z)
+        mod.add_constraint(x + y == z)  # linear EQ
+        mod.add_constraint(x + y >= z)  # linear GE
+        mod.add_constraint(x + y <= z)  # linear LE
+        mod.add_constraint(x * y == z)  # quadratic EQ
+        mod.add_constraint(x * y >= z)  # quadratic GE
+        mod.add_constraint(x * y <= z)  # quadratic LE
         q_p = QuadraticProgram()
         q_p.from_docplex(mod)
         var_names = [v.name for v in q_p.variables]

--- a/test/test_quadratic_program.py
+++ b/test/test_quadratic_program.py
@@ -120,6 +120,40 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         with self.assertRaises(QiskitOptimizationError):
             q_p.binary_var_dict(name='c', keys=range(3))
 
+        d_4 = q_p.binary_var_dict(1, 'x', '_')
+        self.assertSetEqual(set(d_4.keys()), {'x_'})
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8',
+                             'c0', 'c1', 'c2', 'x_'})
+        for var in q_p.variables[-1:]:
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, 1)
+            self.assertEqual(var.vartype, VarType.BINARY)
+            self.assertTupleEqual(var.as_tuple(), d_4[var.name].as_tuple())
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.binary_var_dict(1, 'x', '_')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.binary_var('x_')
+
+        d_5 = q_p.continuous_var_dict(1, -1, 2, '', '')
+        self.assertSetEqual(set(d_5.keys()), {''})
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8',
+                             'c0', 'c1', 'c2', 'x_', ''})
+        for var in q_p.variables[-1:]:
+            self.assertAlmostEqual(var.lowerbound, -1)
+            self.assertAlmostEqual(var.upperbound, 2)
+            self.assertEqual(var.vartype, VarType.CONTINUOUS)
+            self.assertTupleEqual(var.as_tuple(), d_5[var.name].as_tuple())
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.binary_var_dict(1, '', '')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.integer_var(0, 1, '')
+
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
             q_p.binary_var_dict(keys=1, key_format='{}{}')
@@ -131,6 +165,14 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
             q_p.binary_var_dict(keys=1, key_format='_{{}}')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p = QuadraticProgram()
+            q_p.binary_var_dict(keys=2, key_format='')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p = QuadraticProgram()
+            q_p.binary_var_dict(keys=range(2), key_format='')
 
     def test_var_list(self):
         """test {binary,integer,continuous}_var_list"""
@@ -183,6 +225,42 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         with self.assertRaises(QiskitOptimizationError):
             q_p.binary_var_list(name='c', keys=range(3))
 
+        d_4 = q_p.binary_var_dict(1, 'x', '_')
+        names = ['x_']
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8',
+                             'c0', 'c1', 'c2', 'x_'})
+        for i, var in enumerate(q_p.variables[-1:]):
+            self.assertEqual(var.name, names[i])
+            self.assertAlmostEqual(var.lowerbound, 0)
+            self.assertAlmostEqual(var.upperbound, 1)
+            self.assertEqual(var.vartype, VarType.BINARY)
+            self.assertTupleEqual(var.as_tuple(), d_4[var.name].as_tuple())
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.binary_var_list(1, 'x', '_')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.binary_var('x_')
+
+        d_5 = q_p.integer_var_list(1, -1, 2, '', '')
+        names = ['']
+        self.assertSetEqual({var.name for var in q_p.variables},
+                            {'a_0', 'a_1', 'a_2', 'b3', 'b4', 'b5', 'b6', 'b7', 'x-8',
+                             'c0', 'c1', 'c2', 'x_', ''})
+        for i, var in enumerate(q_p.variables[-1:]):
+            self.assertEqual(var.name, names[i])
+            self.assertAlmostEqual(var.lowerbound, -1)
+            self.assertAlmostEqual(var.upperbound, 2)
+            self.assertEqual(var.vartype, VarType.INTEGER)
+            self.assertTupleEqual(var.as_tuple(), d_5[i].as_tuple())
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.binary_var_list(1, '', '')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p.integer_var(0, 1, '')
+
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
             q_p.binary_var_list(keys=1, key_format='{}{}')
@@ -194,6 +272,14 @@ class TestQuadraticProgram(QiskitOptimizationTestCase):
         with self.assertRaises(QiskitOptimizationError):
             q_p = QuadraticProgram()
             q_p.binary_var_list(keys=1, key_format='_{{}}')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p = QuadraticProgram()
+            q_p.binary_var_list(keys=2, key_format='')
+
+        with self.assertRaises(QiskitOptimizationError):
+            q_p = QuadraticProgram()
+            q_p.binary_var_list(keys=range(2), key_format='')
 
     def test_variables_handling(self):
         """ test add variables """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes https://github.com/Qiskit/qiskit-aqua/issues/1462
Copy of https://github.com/Qiskit/qiskit-aqua/pull/1507

This PR moves `keys` argument first to match with [docplex interface](http://ibmdecisionoptimization.github.io/docplex-doc/mp/docplex.mp.model.html?highlight=solve_details#docplex.mp.model.Model.binary_var_dict). `keys` should be given explicitly because the methods are to generate multiple variables at once. `keys=None` does not make sense.

These methods are introduced only in master of Aqua and not yet included in the released version.


### Details and comments

- [X] Simplify the internal of variable generation.
- [X] Avoid an infinite loop due to variable index search.
- [x] Cleanup of unit tests.
- [x] Lint