### PR TITLE
Deal with both old and new locations of Var of docplex

### DIFF
--- a/qiskit_optimization/applications/ising/docplex.py
+++ b/qiskit_optimization/applications/ising/docplex.py
@@ -57,17 +57,24 @@ The following is an example of use.
 
 """
 
-from typing import Tuple, Union, List
 import logging
 from math import fsum
+from typing import Tuple, Union, List
 
 import numpy as np
 from docplex.mp.constants import ComparisonType
 from docplex.mp.constr import LinearConstraint, QuadraticConstraint
-from docplex.mp.dvar import Var
+
+try:
+    # new location since docplex 2.16.196
+    from docplex.mp.dvar import Var
+except ImportError:
+    # old location until docplex 2.15.194
+    from docplex.mp.linear import Var
 from docplex.mp.model import Model
-from qiskit.quantum_info import Pauli
+
 from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import Pauli
 
 from ...exceptions import QiskitOptimizationError
 

--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -24,7 +24,13 @@ import numpy as np
 from docplex.mp.constr import LinearConstraint as DocplexLinearConstraint
 from docplex.mp.constr import NotEqualConstraint
 from docplex.mp.constr import QuadraticConstraint as DocplexQuadraticConstraint
-from docplex.mp.dvar import Var
+
+try:
+    # new location since docplex 2.16.196
+    from docplex.mp.dvar import Var
+except ImportError:
+    # old location until docplex 2.15.194
+    from docplex.mp.linear import Var
 from docplex.mp.model import Model
 from docplex.mp.model_reader import ModelReader
 from docplex.mp.quad import QuadExpr

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ qiskit-terra>=0.17.0
 scipy>=1.4
 numpy>=1.17
 psutil>=5
-docplex
+docplex>=2.16.196
 setuptools>=40.1.0
 retworkx>=0.5.0
 dataclasses; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ qiskit-terra>=0.17.0
 scipy>=1.4
 numpy>=1.17
 psutil>=5
-docplex
+docplex; sys_platform != 'darwin'
+docplex==2.15.194; sys_platform == 'darwin'
 setuptools>=40.1.0
 retworkx>=0.5.0
 dataclasses; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ qiskit-terra>=0.17.0
 scipy>=1.4
 numpy>=1.17
 psutil>=5
-docplex>=2.16.196
+docplex
 setuptools>=40.1.0
 retworkx>=0.5.0
 dataclasses; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "scipy>=1.4",
     "numpy>=1.17",
     "psutil>=5",
-    "docplex",
+    "docplex>=2.16.196",
     "setuptools>=40.1.0",
     "retworkx>=0.5.0",
     "dataclasses; python_version < '3.7'"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "scipy>=1.4",
     "numpy>=1.17",
     "psutil>=5",
-    "docplex>=2.16.196",
+    "docplex",
     "setuptools>=40.1.0",
     "retworkx>=0.5.0",
     "dataclasses; python_version < '3.7'"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ requirements = [
     "scipy>=1.4",
     "numpy>=1.17",
     "psutil>=5",
-    "docplex",
+    "docplex; sys_platform != 'darwin'",
+    "docplex==2.15.194; sys_platform == 'darwin'",
     "setuptools>=40.1.0",
     "retworkx>=0.5.0",
     "dataclasses; python_version < '3.7'"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow-up of #22 

I replaced `mp.linear.Var` with `mp.dvar.Var` to be compatible with the latest docplex 2.20.204.
`mp.linear.Var` was used until 2.15.194. So, I modified the code to work with both styles.

I add a version pin docplex==2.15.194 for macOS because docplex does not work without cplex on macOS.
See #24 for details.

### Details and comments


