### PR TITLE
Remove decorator from requirements, added during its buggy period

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ numpy>=1.17
 docplex; sys_platform != 'darwin'
 docplex==2.15.194; sys_platform == 'darwin'
 setuptools>=40.1.0
-networkx>=2.2
-decorator<5.0
+networkx>=2.5.1
 dataclasses; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.17
 docplex; sys_platform != 'darwin'
 docplex==2.15.194; sys_platform == 'darwin'
 setuptools>=40.1.0
-networkx>=2.5.1
+networkx>=2.2
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

### Details and comments

Decorator had a backward compatibility problem that was affecting networkx for 2 days but the intermediate buggy versions were yanked and a fix was released.
In the meantime, I had added a pin to decorator in requirements.txt in order to publish our docs which is unnecessary now. I am reverting to as it used to be.
