### PR TITLE
[Stable] Remove decorator from requirements, added during its buggy period

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ docplex; sys_platform != 'darwin'
 docplex==2.15.194; sys_platform == 'darwin'
 setuptools>=40.1.0
 networkx>=2.2
-decorator<5.0
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
* Remove decorator dependency and restore previous networkx min.requirements

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Cherry-pick of #71

### Details and comments


