### PR TITLE
Increase num qubit for grover bit ordering unit test

### DIFF
--- a/test/algorithms/test_grover_optimizer.py
+++ b/test/algorithms/test_grover_optimizer.py
@@ -231,7 +231,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         op.from_docplex(mdl)
         opt_sol = -2
         success = OptimizationResultStatus.SUCCESS
-        grover_optimizer = GroverOptimizer(3, num_iterations=10, quantum_instance=q_instance)
+        grover_optimizer = GroverOptimizer(4, num_iterations=10, quantum_instance=q_instance)
         results = grover_optimizer.solve(op)
         self.assertEqual(results.fval, opt_sol)
         np.testing.assert_array_almost_equal(results.x, [0, 1])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow-up of #97 

I notice that a unit test may fail on Linux as follows.
```
======================================================================
FAIL: test_bit_ordering_1_sv (test.algorithms.test_grover_optimizer.TestGroverOptimizer)
Test bit ordering
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ima/envs/dev/lib/python3.8/site-packages/ddt.py", line 182, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ima/qiskit/opt/test/algorithms/test_grover_optimizer.py", line 236, in test_bit_ordering
    self.assertEqual(results.fval, opt_sol)
AssertionError: 0.0 != -2
----------------------------------------------------------------------
```

It is required to make #129 pass.

### Details and comments


