### PR TITLE
Fix GroverOptimizer's rotation_count

### DIFF
--- a/qiskit_optimization/algorithms/grover_optimizer.py
+++ b/qiskit_optimization/algorithms/grover_optimizer.py
@@ -142,7 +142,7 @@ class GroverOptimizer(OptimizationAlgorithm):
         oracle = QuantumCircuit(qr_key_value, oracle_bit)
         oracle.z(self._num_key_qubits)  # recognize negative values.
 
-        def is_good_state(self, measurement):
+        def is_good_state(measurement):
             """Check whether ``measurement`` is a good state or not."""
             value = measurement[
                 self._num_key_qubits : self._num_key_qubits + self._num_value_qubits
@@ -225,7 +225,7 @@ class GroverOptimizer(OptimizationAlgorithm):
             while not improvement_found:
                 # Determine the number of rotations.
                 loops_with_no_improvement += 1
-                rotation_count = int(np.ceil(algorithm_globals.random.uniform(0, m - 1)))
+                rotation_count = algorithm_globals.random.integers(0, m)
                 rotations += rotation_count
                 # Apply Grover's Algorithm to find values below the threshold.
                 # TODO: Utilize Grover's incremental feature - requires changes to Grover.
@@ -323,11 +323,9 @@ class GroverOptimizer(OptimizationAlgorithm):
     def _measure(self, circuit: QuantumCircuit) -> str:
         """Get probabilities from the given backend, and picks a random outcome."""
         probs = self._get_probs(circuit)
-        freq = sorted(probs.items(), key=lambda x: x[1], reverse=True)
+        logger.info("Frequencies: %s", probs)
         # Pick a random outcome.
-        idx = algorithm_globals.random.choice(len(freq), 1, p=[x[1] for x in freq])[0]
-        logger.info("Frequencies: %s", freq)
-        return freq[idx][0]
+        return algorithm_globals.random.choice(list(probs.keys()), 1, p=list(probs.values()))[0]
 
     def _get_probs(self, qc: QuantumCircuit) -> Dict[str, float]:
         """Gets probabilities from a given backend."""
@@ -346,7 +344,7 @@ class GroverOptimizer(OptimizationAlgorithm):
         else:
             state = result.get_counts(qc)
             shots = self.quantum_instance.run_config.shots
-            hist = {key[::-1]: val / shots for key, val in state.items() if val > 0}
+            hist = {key[::-1]: val / shots for key, val in sorted(state.items()) if val > 0}
             self._circuit_results = {b: (v / shots) ** 0.5 for (b, v) in state.items()}
         return hist
 

--- a/releasenotes/notes/fix-grover-rotation-count-853baefc6b7e8476.yaml
+++ b/releasenotes/notes/fix-grover-rotation-count-853baefc6b7e8476.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixes ``rotation_count`` in :class`qiskit_optimization.algorithms.GroverOptimizer`.
+    This fix uses ``algorithm_globals.random.integers(0, m)`` to generate a random integer
+    in a range 0..``m``-1.
+  - |
+    Sorts the order of ``result.get_counts(qc)`` by bitstring
+    in :class`qiskit_optimization.algorithms.GroverOptimizer` when ``qasm_simulator`` is used
+    so that the algorithm behaves deterministically.
+    The previous version sorts the counts by probabilities, but some bitstrings may have
+    the same probability and the algorithm could behave probabilistically.

--- a/test/algorithms/test_grover_optimizer.py
+++ b/test/algorithms/test_grover_optimizer.py
@@ -50,6 +50,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         self.qasm_simulator = QuantumInstance(
             Aer.get_backend("qasm_simulator"), seed_simulator=123, seed_transpiler=123
         )
+        self.n_iter = 8
 
     def validate_results(self, problem, results):
         """Validate the results object returned by GroverOptimizer."""
@@ -91,8 +92,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         op.from_docplex(model)
 
         # Get the optimum key and value.
-        n_iter = 8
-        gmf = GroverOptimizer(4, num_iterations=n_iter, quantum_instance=self.sv_simulator)
+        gmf = GroverOptimizer(4, num_iterations=self.n_iter, quantum_instance=self.sv_simulator)
         results = gmf.solve(op)
         self.validate_results(op, results)
 
@@ -112,8 +112,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         op.from_docplex(model)
 
         # Get the optimum key and value.
-        n_iter = 8
-        gmf = GroverOptimizer(4, num_iterations=n_iter, quantum_instance=self.sv_simulator)
+        gmf = GroverOptimizer(4, num_iterations=self.n_iter, quantum_instance=self.sv_simulator)
         results = gmf.solve(op)
         self.validate_results(op, results)
 
@@ -134,10 +133,8 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         op.from_docplex(model)
 
         # Get the optimum key and value.
-        n_iter = 10
-
         q_instance = self.sv_simulator if simulator == "sv" else self.qasm_simulator
-        gmf = GroverOptimizer(6, num_iterations=n_iter, quantum_instance=q_instance)
+        gmf = GroverOptimizer(6, num_iterations=self.n_iter, quantum_instance=q_instance)
         results = gmf.solve(op)
         self.validate_results(op, results)
 
@@ -153,12 +150,11 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         op.from_docplex(model)
 
         # Get the optimum key and value.
-        n_iter = 8
         # a single converter.
         qp2qubo = QuadraticProgramToQubo()
         gmf = GroverOptimizer(
             4,
-            num_iterations=n_iter,
+            num_iterations=self.n_iter,
             quantum_instance=self.sv_simulator,
             converters=qp2qubo,
         )
@@ -172,7 +168,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         converters = [ineq2eq, int2bin, penalize]
         gmf = GroverOptimizer(
             4,
-            num_iterations=n_iter,
+            num_iterations=self.n_iter,
             quantum_instance=self.sv_simulator,
             converters=converters,
         )
@@ -183,7 +179,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
             invalid = [qp2qubo, "invalid converter"]
             GroverOptimizer(
                 4,
-                num_iterations=n_iter,
+                num_iterations=self.n_iter,
                 quantum_instance=self.sv_simulator,
                 converters=invalid,
             )
@@ -191,13 +187,16 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
     @data("sv", "qasm")
     def test_samples_and_raw_samples(self, simulator):
         """Test samples and raw_samples"""
+        algorithm_globals.random_seed = 2
         op = QuadraticProgram()
         op.integer_var(0, 3, "x")
         op.binary_var("y")
         op.minimize(linear={"x": 1, "y": 2})
         op.linear_constraint(linear={"x": 1, "y": 1}, sense=">=", rhs=1, name="xy")
         q_instance = self.sv_simulator if simulator == "sv" else self.qasm_simulator
-        grover_optimizer = GroverOptimizer(8, num_iterations=10, quantum_instance=q_instance)
+        grover_optimizer = GroverOptimizer(
+            8, num_iterations=self.n_iter, quantum_instance=q_instance
+        )
         opt_sol = 1
         success = OptimizationResultStatus.SUCCESS
         results = grover_optimizer.solve(op)
@@ -231,7 +230,9 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         op.from_docplex(mdl)
         opt_sol = -2
         success = OptimizationResultStatus.SUCCESS
-        grover_optimizer = GroverOptimizer(3, num_iterations=10, quantum_instance=q_instance)
+        grover_optimizer = GroverOptimizer(
+            3, num_iterations=self.n_iter, quantum_instance=q_instance
+        )
         results = grover_optimizer.solve(op)
         self.assertEqual(results.fval, opt_sol)
         np.testing.assert_array_almost_equal(results.x, [0, 1])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #129

GroverOptimizer's rotation_count is set in a wrong way.
It is originally `rotation_count = int(np.ceil(algorithm_globals.random.uniform(0, m - 1)))`, but it is always 1 if `m=1`.
It should be either 0 or 1. So, I replace it with `algorithm_globals.random.integers(0, m)`.

The order of `result.get_counts(qc)` has an issue. It is sorted by probability, but some bitstrings may have the same probabilities and it results in a probabilistic behavior of unit tests on different environment (mac and linux).
This PR sorts the counts by bitstring order if qasm_simulator is used. So, the resulting iterator has the same order in any environment.
If statevector_simulator is used, it omits the sort because the results are generated in a sorted order.


### Details and comments


