### PR TITLE
Add types-dataclasses for mypy-0.900

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ mypy>=0.780
 mypy-extensions>=0.4.3
 nbsphinx
 qiskit_sphinx_theme
+types-dataclasses; python_version < '3.7'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Mypy 0.900, released recently, requires `types-dataclasses`. Mypy shows the following message with Python 3.6.
This PR fixes requirements.txt.

```
qiskit_optimization/algorithms/optimization_algorithm.py:16: error: Library stubs not installed for "dataclasses" (or incompatible with Python 3.6)
qiskit_optimization/algorithms/optimization_algorithm.py:16: note: Hint: "python3 -m pip install types-dataclasses"
qiskit_optimization/algorithms/optimization_algorithm.py:16: note: (or run "mypy --install-types" to install all missing stub packages)
qiskit_optimization/algorithms/optimization_algorithm.py:16: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

### Details and comments


