### PR TITLE
Refactor converters and `MinimumEigenOptimizer`

### DIFF
--- a/qiskit_optimization/algorithms/admm_optimizer.py
+++ b/qiskit_optimization/algorithms/admm_optimizer.py
@@ -682,7 +682,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
         quadratic_y = self._params.beta / 2 * np.eye(binary_size) + self._state.rho / 2 * np.eye(
             binary_size
         )
-        op3.objective.quadratic = quadratic_y
+        op3.objective.quadratic = quadratic_y  # type: ignore[assignment]
 
         # set linear objective for y
         linear_y = -self._state.lambda_mult - self._state.rho * (self._state.x0 - self._state.z)

--- a/qiskit_optimization/algorithms/grover_optimizer.py
+++ b/qiskit_optimization/algorithms/grover_optimizer.py
@@ -176,7 +176,7 @@ class GroverOptimizer(OptimizationAlgorithm):
         problem_ = self._convert(problem, self._converters)
         problem_init = deepcopy(problem_)
 
-        self._num_key_qubits = len(problem_.objective.linear.to_array())  # type: ignore
+        self._num_key_qubits = len(problem_.objective.linear.to_array())
 
         # Variables for tracking the optimum.
         optimum_found = False

--- a/qiskit_optimization/algorithms/grover_optimizer.py
+++ b/qiskit_optimization/algorithms/grover_optimizer.py
@@ -261,7 +261,7 @@ class GroverOptimizer(OptimizationAlgorithm):
                         self._circuit_results, problem_init
                     )
                     raw_samples.sort(key=lambda x: x.fval)
-                    samples = self._interpret_samples(problem, raw_samples, self._converters)
+                    samples, _ = self._interpret_samples(problem, raw_samples, self._converters)
                 else:
                     # Using Durr and Hoyer method, increase m.
                     m = int(np.ceil(min(m * 8 / 7, 2 ** (n_key / 2))))

--- a/qiskit_optimization/algorithms/optimization_algorithm.py
+++ b/qiskit_optimization/algorithms/optimization_algorithm.py
@@ -211,7 +211,7 @@ class OptimizationResult:
         return self._x
 
     @property
-    def fval(self) -> float:
+    def fval(self) -> Optional[float]:
         """Returns the optimal function value.
 
         Returns:

--- a/qiskit_optimization/applications/optimization_application.py
+++ b/qiskit_optimization/applications/optimization_application.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """An abstract class for optimization application classes."""
-from typing import Union
+from typing import Union, Dict
 from collections import OrderedDict
 from abc import ABC, abstractmethod
 
@@ -59,7 +59,7 @@ class OptimizationApplication(ABC):
         return x
 
     @staticmethod
-    def sample_most_likely(state_vector: Union[np.ndarray, dict]) -> np.ndarray:
+    def sample_most_likely(state_vector: Union[np.ndarray, Dict]) -> np.ndarray:
         """Compute the most likely binary string from state vector.
 
         Args:

--- a/qiskit_optimization/converters/flip_problem_sense.py
+++ b/qiskit_optimization/converters/flip_problem_sense.py
@@ -28,7 +28,7 @@ class _FlipProblemSense(QuadraticProgramConverter):
     vice versa, regardless of the current sense."""
 
     def __init__(self) -> None:
-        self._src_num_vars = None  # type: Optional[int]
+        self._src_num_vars: Optional[int] = None
 
     def convert(self, problem: QuadraticProgram) -> QuadraticProgram:
         """Flip the sense of a problem.

--- a/qiskit_optimization/converters/inequality_to_equality.py
+++ b/qiskit_optimization/converters/inequality_to_equality.py
@@ -49,8 +49,8 @@ class InequalityToEquality(QuadraticProgramConverter):
                 - 'auto': Try to use integer variables but if it's not possible,
                    use continuous variables
         """
-        self._src = None  # type: Optional[QuadraticProgram]
-        self._dst = None  # type: Optional[QuadraticProgram]
+        self._src: Optional[QuadraticProgram] = None
+        self._dst: Optional[QuadraticProgram] = None
         self._mode = mode
 
     def convert(self, problem: QuadraticProgram) -> QuadraticProgram:

--- a/qiskit_optimization/converters/integer_to_binary.py
+++ b/qiskit_optimization/converters/integer_to_binary.py
@@ -46,9 +46,9 @@ class IntegerToBinary(QuadraticProgramConverter):
     _delimiter = "@"  # users are supposed not to use this character in variable names
 
     def __init__(self) -> None:
-        self._src = None  # type: Optional[QuadraticProgram]
-        self._dst = None  # type: Optional[QuadraticProgram]
-        self._conv = {}  # type: Dict[Variable, List[Tuple[str, int]]]
+        self._src: Optional[QuadraticProgram] = None
+        self._dst: Optional[QuadraticProgram] = None
+        self._conv: Dict[Variable, List[Tuple[str, int]]] = {}
         # e.g., self._conv = {x: [('x@1', 1), ('x@2', 2)]}
 
     def convert(self, problem: QuadraticProgram) -> QuadraticProgram:
@@ -111,7 +111,7 @@ class IntegerToBinary(QuadraticProgramConverter):
         self, coefficients: Dict[str, float]
     ) -> Tuple[Dict[str, float], float]:
         constant = 0.0
-        linear = {}  # type: Dict[str, float]
+        linear: Dict[str, float] = {}
         for name, v in coefficients.items():
             x = self._src.get_variable(name)
             if x in self._conv:
@@ -127,7 +127,7 @@ class IntegerToBinary(QuadraticProgramConverter):
         self, coefficients: Dict[Tuple[str, str], float]
     ) -> Tuple[Dict[Tuple[str, str], float], Dict[str, float], float]:
         constant = 0.0
-        linear = {}  # type: Dict[str, float]
+        linear: Dict[str, float] = {}
         quadratic = {}
         for (name_i, name_j), v in coefficients.items():
             x = self._src.get_variable(name_i)

--- a/qiskit_optimization/converters/linear_equality_to_penalty.py
+++ b/qiskit_optimization/converters/linear_equality_to_penalty.py
@@ -12,7 +12,6 @@
 
 """Converter to convert a problem with equality constraints to unconstrained with penalty terms."""
 
-import copy
 import logging
 from math import fsum
 from typing import Optional, cast, Union, Tuple, List
@@ -125,7 +124,8 @@ class LinearEqualityToPenalty(QuadraticProgramConverter):
 
         return dst
 
-    def _auto_define_penalty(self, problem: QuadraticProgram) -> float:
+    @staticmethod
+    def _auto_define_penalty(problem: QuadraticProgram) -> float:
         """Automatically define the penalty coefficient.
 
         Returns:

--- a/qiskit_optimization/converters/quadratic_program_to_qubo.py
+++ b/qiskit_optimization/converters/quadratic_program_to_qubo.py
@@ -12,13 +12,17 @@
 
 """A converter from quadratic program to a QUBO."""
 
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 import numpy as np
 
-from .quadratic_program_converter import QuadraticProgramConverter
+from ..converters.flip_problem_sense import MaximizeToMinimize
+from ..converters.inequality_to_equality import InequalityToEquality
+from ..converters.integer_to_binary import IntegerToBinary
+from ..converters.linear_equality_to_penalty import LinearEqualityToPenalty
 from ..exceptions import QiskitOptimizationError
 from ..problems.quadratic_program import QuadraticProgram
+from .quadratic_program_converter import QuadraticProgramConverter
 
 
 class QuadraticProgramToQubo(QuadraticProgramConverter):
@@ -40,15 +44,14 @@ class QuadraticProgramToQubo(QuadraticProgramConverter):
                 If None is passed, a penalty factor will be automatically calculated on every
                 conversion.
         """
-        from ..converters.integer_to_binary import IntegerToBinary
-        from ..converters.inequality_to_equality import InequalityToEquality
-        from ..converters.linear_equality_to_penalty import LinearEqualityToPenalty
-        from ..converters.flip_problem_sense import MaximizeToMinimize
 
-        self._int_to_bin = IntegerToBinary()
-        self._ineq_to_eq = InequalityToEquality(mode="integer")
         self._penalize_lin_eq_constraints = LinearEqualityToPenalty(penalty=penalty)
-        self._max_to_min = MaximizeToMinimize()
+        self._converters = [
+            InequalityToEquality(mode="integer"),
+            IntegerToBinary(),
+            self._penalize_lin_eq_constraints,
+            MaximizeToMinimize(),
+        ]
 
     def convert(self, problem: QuadraticProgram) -> QuadraticProgram:
         """Convert a problem with linear constraints into new one with a QUBO form.
@@ -68,20 +71,9 @@ class QuadraticProgramToQubo(QuadraticProgramConverter):
         if len(msg) > 0:
             raise QiskitOptimizationError("Incompatible problem: {}".format(msg))
 
-        # Convert inequality constraints into equality constraints by adding slack variables
-        problem_ = self._ineq_to_eq.convert(problem)
-
-        # Map integer variables to binary variables
-        problem_ = self._int_to_bin.convert(problem_)
-
-        # Penalize linear equality constraints with only binary variables
-        problem_ = self._penalize_lin_eq_constraints.convert(problem_)
-
-        # Convert maximization to minimization problem
-        problem_ = self._max_to_min.convert(problem_)
-
-        # Return QUBO
-        return problem_
+        for conv in self._converters:
+            problem = conv.convert(problem)
+        return problem
 
     def interpret(self, x: Union[np.ndarray, List[float]]) -> np.ndarray:
         """Convert a result of a converted problem into that of the original problem.
@@ -92,10 +84,8 @@ class QuadraticProgramToQubo(QuadraticProgramConverter):
         Returns:
             The result of the original problem.
         """
-        x = self._max_to_min.interpret(x)
-        x = self._penalize_lin_eq_constraints.interpret(x)
-        x = self._int_to_bin.interpret(x)
-        x = self._ineq_to_eq.interpret(x)
+        for conv in self._converters[::-1]:
+            x = conv.interpret(x)
         return x
 
     @staticmethod

--- a/qiskit_optimization/converters/quadratic_program_to_qubo.py
+++ b/qiskit_optimization/converters/quadratic_program_to_qubo.py
@@ -12,7 +12,7 @@
 
 """A converter from quadratic program to a QUBO."""
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, cast
 
 import numpy as np
 
@@ -86,7 +86,7 @@ class QuadraticProgramToQubo(QuadraticProgramConverter):
         """
         for conv in self._converters[::-1]:
             x = conv.interpret(x)
-        return x
+        return cast(np.ndarray, x)
 
     @staticmethod
     def get_compatibility_msg(problem: QuadraticProgram) -> str:

--- a/qiskit_optimization/problems/quadratic_objective.py
+++ b/qiskit_optimization/problems/quadratic_objective.py
@@ -13,7 +13,7 @@
 """Quadratic Objective."""
 
 from enum import Enum
-from typing import Union, List, Dict, Tuple, Any
+from typing import Union, List, Dict, Tuple, Any, Optional
 
 from numpy import ndarray
 from scipy.sparse import spmatrix
@@ -42,12 +42,16 @@ class QuadraticObjective(QuadraticProgramElement):
         self,
         quadratic_program: Any,
         constant: float = 0.0,
-        linear: Union[ndarray, spmatrix, List[float], Dict[Union[str, int], float]] = None,
-        quadratic: Union[
-            ndarray,
-            spmatrix,
-            List[List[float]],
-            Dict[Tuple[Union[int, str], Union[int, str]], float],
+        linear: Optional[
+            Union[ndarray, spmatrix, List[float], Dict[Union[str, int], float]]
+        ] = None,
+        quadratic: Optional[
+            Union[
+                ndarray,
+                spmatrix,
+                List[List[float]],
+                Dict[Tuple[Union[int, str], Union[int, str]], float],
+            ]
         ] = None,
         sense: ObjSense = ObjSense.MINIMIZE,
     ) -> None:

--- a/releasenotes/notes/min-eigen-opt-order-9e030bb2d8d63656.yaml
+++ b/releasenotes/notes/min-eigen-opt-order-9e030bb2d8d63656.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+      Changes :meth:`qiskit_optimization.algorithms.MinimumEigenOptimizer.solve`
+      to return the best solution in terms of the original problem,
+      i.e., ``MinimumEigenOptimizationResult.samples[0]``,
+      as :meth:`qiskit_optimization.algorithms.MinimumEigenOptimizationResult.x`.
+      It used to be the best solution in terms of the converted QUBO problem,
+      i.e., ``MinimumEigenOptimizationResult.raw_samples[0]``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Changed `MinimumEigenOptimizer` to return the best solution in terms of the original problem. See details.
- Simplified `MinimumEigenOptimizer` and `QuadraticProgramToQubo`
- Removed unnecessary deepcopy in converters
- Revised type hints
- Replace error messages with f-strings

Note: need to address  #175 to pass CI

### Details and comments

The current implementation `MinimumEigenOptimizer` returns the best solution `raw_samples[0].x` among `raw_samples` in terms of QUBO as `MinimumEigenOptimizationResult.x`. But, it is not always the best solution in terms of the original problem because inequality constraints are converted into penalties as part of QUBO. So, I changed `MinimumEigenOptimizer` to return the best solution in terms of the original problem as `MinimumEigenOptimizationResult.x`.