### PR TITLE
Revert `_should_define_penalty` of `LinearEqualityToPenalty`

### DIFF
--- a/qiskit_optimization/converters/linear_equality_to_penalty.py
+++ b/qiskit_optimization/converters/linear_equality_to_penalty.py
@@ -40,6 +40,7 @@ class LinearEqualityToPenalty(QuadraticProgramConverter):
         """
         self._src_num_vars: Optional[int] = None
         self._penalty: Optional[float] = penalty
+        self._should_define_penalty: bool = penalty is None
 
     def convert(self, problem: QuadraticProgram) -> QuadraticProgram:
         """Convert a problem with equality constraints into an unconstrained problem.
@@ -59,7 +60,7 @@ class LinearEqualityToPenalty(QuadraticProgramConverter):
         dst = QuadraticProgram(name=problem.name)
 
         # If no penalty was given, set the penalty coefficient by _auto_define_penalty()
-        if self._penalty is None:
+        if self._should_define_penalty:
             penalty = self._auto_define_penalty(problem)
         else:
             penalty = self._penalty
@@ -201,3 +202,4 @@ class LinearEqualityToPenalty(QuadraticProgramConverter):
                      on every conversion.
         """
         self._penalty = penalty
+        self._should_define_penalty = penalty is None

--- a/test/converters/test_converters.py
+++ b/test/converters/test_converters.py
@@ -555,6 +555,28 @@ class TestConverters(QiskitOptimizationTestCase):
         lineq2penalty.convert(op)
         self.assertEqual(4, lineq2penalty.penalty)
 
+    def test_penalty_recalculation_when_reusing2(self):
+        """Test the penalty retrieval and recalculation of LinearEqualityToPenalty 2"""
+        op = QuadraticProgram()
+        op.binary_var("x")
+        op.binary_var("y")
+        op.binary_var("z")
+        op.minimize(constant=3, linear={"x": 1}, quadratic={("x", "y"): 2})
+        op.linear_constraint(linear={"x": 1, "y": 1, "z": 1}, sense="EQ", rhs=2, name="xyz_eq")
+        # First, create a converter with no penalty
+        lineq2penalty = LinearEqualityToPenalty()
+        self.assertIsNone(lineq2penalty.penalty)
+        # Then converter must calculate the penalty for the problem (should be 4.0)
+        lineq2penalty.convert(op)
+        self.assertEqual(4, lineq2penalty.penalty)
+        # Re-use the converter for a new problem
+        op2 = QuadraticProgram()
+        op2.binary_var("x")
+        op2.minimize(linear={"x": 10})
+        op2.linear_constraint({"x": 1}, "==", 0)
+        lineq2penalty.convert(op2)
+        self.assertEqual(11, lineq2penalty.penalty)
+
     def test_linear_equality_to_penalty_decode(self):
         """Test decode func of LinearEqualityToPenalty"""
         qprog = QuadraticProgram()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I simplified the penalty term of `LinearEqualityToPenalty` in #174.
But, @a-matsuo told me that it is oversimplified https://github.com/Qiskit/qiskit-optimization/pull/157#discussion_r659453113.
I revert `_should_define_penalty` so that `LinearEqualityToPenalty._auto_define_penalty` is invoked even if `LinearEqualityToPenalty` is reused for other optimization problems.

The details are in #34.


### Details and comments


