### PR TITLE
Fix a warning by pylint 2.9.0

### DIFF
--- a/qiskit_optimization/algorithms/warm_start_qaoa_optimizer.py
+++ b/qiskit_optimization/algorithms/warm_start_qaoa_optimizer.py
@@ -92,12 +92,12 @@ class MeanAggregator(BaseAggregator):
         # Divide by the number of results to normalize
         aggregated_samples = []
         num_results = len(results)
-        for state in dict_samples:
+        for state, val_prob in dict_samples.items():
             # sample = (state, dict_samples[state][0], dict_samples[state][1] / num_results)
             sample = SolutionSample(
                 x=_from_string(state),
-                fval=dict_samples[state][0],
-                probability=dict_samples[state][1] / num_results,
+                fval=val_prob[0],
+                probability=val_prob[1] / num_results,
                 status=OptimizationResultStatus.SUCCESS,
             )
             aggregated_samples.append(sample)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Pylint 2.9.0 is released today. This PR fixes the following warning raised by pylint 2.9.0.
```
************* Module qiskit_optimization.algorithms.warm_start_qaoa_optimizer
qiskit_optimization/algorithms/warm_start_qaoa_optimizer.py:95:8: C0206: Consider iterating with .items() (consider-using-dict-items)
```

### Details and comments


