### PR TITLE
Fixed typos

### DIFF
--- a/qiskit_optimization/__init__.py
+++ b/qiskit_optimization/__init__.py
@@ -40,7 +40,7 @@ well as equality and inequality constraints. This class of optimization problems
 of relevant applications, while still being efficiently representable by matrices and vectors.
 This class covers some very interesting sub-classes, from Convex Continuous Quadratic Programs,
 which can be solved efficiently by classical optimization algorithms, to Quadratic Unconstrained
-Binary Optimization QUBO) problems, which cover many NP-complete, i.e., classically intractable,
+Binary Optimization (QUBO) problems, which cover many NP-complete, i.e., classically intractable,
 problems.
 
 .. autosummary::

--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -502,7 +502,7 @@ class QuadraticProgram:
         key_format: str = "{}",
     ) -> List[Variable]:
         """
-        Uses 'var_list' to construct a dictionary of integer variables
+        Uses 'var_list' to construct a list of integer variables
 
         Args:
             lowerbound: The lower bound of the variable(s).

--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -1036,7 +1036,7 @@ class QuadraticProgram:
             offset: The constant value in the Ising Hamiltonian.
             linear: If linear is True, :math:`x^2` is treated as a linear term
                 since :math:`x^2 = x` for :math:`x \in \{0,1\}`.
-                Else, :math:`x^2` is treat as a quadratic term.
+                Else, :math:`x^2` is treated as a quadratic term.
                 The default value is False.
 
         Raises:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed several typos found on `QuadraticProgram` class.

- In the docstring of the `integer_var_list` function, "Uses 'var_list' to construct a dictionary of integer variables" was changed to "Uses 'var_list' to construct a list of integer variables".
- Docstring for `from_ising` function said "Else, x^2 is treat as a quadratic term". Here, "treat" was changed to "treated".
- In `__init__.py`, "Quadratic Unconstrained Binary Optimization (QUBO)" was missing the opening parenthesis.

These typos were found while working on the localization project. 

