### PR TITLE
Fix `IntegerToBinary` converter with quadratic terms and zero range variables

### DIFF
--- a/qiskit_optimization/converters/integer_to_binary.py
+++ b/qiskit_optimization/converters/integer_to_binary.py
@@ -101,7 +101,7 @@ class IntegerToBinary(QuadraticProgramConverter):
         self, name: str, lowerbound: float, upperbound: float
     ) -> List[Tuple[str, int]]:
         var_range = upperbound - lowerbound
-        power = int(np.log2(var_range))
+        power = int(np.log2(var_range)) if var_range > 0 else 0
         bounded_coef = var_range - (2 ** power - 1)
 
         coeffs = [2 ** i for i in range(power)] + [bounded_coef]

--- a/qiskit_optimization/converters/integer_to_binary.py
+++ b/qiskit_optimization/converters/integer_to_binary.py
@@ -149,9 +149,9 @@ class IntegerToBinary(QuadraticProgramConverter):
                         quadratic[z_x, z_y] = v * coeff_x * coeff_y
 
                 for z_x, coeff_x in self._conv[x]:
-                    linear[z_x] = linear.get(z_x, 0.0) + v * y.lowerbound
+                    linear[z_x] = linear.get(z_x, 0.0) + v * coeff_x * y.lowerbound
                 for z_y, coeff_y in self._conv[y]:
-                    linear[z_y] = linear.get(z_y, 0.0) + v * x.lowerbound
+                    linear[z_y] = linear.get(z_y, 0.0) + v * coeff_y * x.lowerbound
 
                 constant += v * x.lowerbound * y.lowerbound
 

--- a/releasenotes/notes/fix-int2bin-a998f31885d3b9d8.yaml
+++ b/releasenotes/notes/fix-int2bin-a998f31885d3b9d8.yaml
@@ -1,4 +1,9 @@
 ---
 fixes:
   - |
-    Fix :class:`qiskit_optimization.converters.IntegerToBinary` when it converts quadratic terms.
+    Fix :class:`qiskit_optimization.converters.IntegerToBinary` to convert quadratic terms
+    correctly.
+  - |
+    Fix :class:`qiskit_optimization.converters.IntegerToBinary` to convert variables
+    with zero range, i.e., the lower bound is equal to the upper bound,
+    without raising any error.

--- a/releasenotes/notes/fix-int2bin-a998f31885d3b9d8.yaml
+++ b/releasenotes/notes/fix-int2bin-a998f31885d3b9d8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix :class:`qiskit_optimization.converters.IntegerToBinary` when it converts quadratic terms.

--- a/test/converters/test_converters.py
+++ b/test/converters/test_converters.py
@@ -639,6 +639,22 @@ class TestConverters(QiskitOptimizationTestCase):
             self.assertDictEqual(cst.linear.to_dict(), cst2.linear.to_dict())
             self.assertDictEqual(cst.quadratic.to_dict(), cst2.quadratic.to_dict())
 
+    def test_integer_to_binary3(self):
+        """Test integer to binary variables 3"""
+        mod = QuadraticProgram()
+        mod.integer_var(name="x", lowerbound=10, upperbound=13)
+        mod.minimize(quadratic={("x", "x"): 1})
+        mod2 = IntegerToBinary().convert(mod)
+        self.assertListEqual([e.name for e in mod2.variables], ["x@0", "x@1"])
+        self.assertEqual(mod.get_num_linear_constraints(), 0)
+        self.assertEqual(mod.get_num_quadratic_constraints(), 0)
+        self.assertAlmostEqual(mod2.objective.constant, 100)
+        self.assertDictEqual(mod2.objective.linear.to_dict(use_name=True), {"x@0": 20, "x@1": 40})
+        self.assertDictEqual(
+            mod2.objective.quadratic.to_dict(use_name=True),
+            {("x@0", "x@0"): 1, ("x@1", "x@1"): 4, ("x@0", "x@1"): 4},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes two issues of `IntegerToBinary`.

First issue is #227. As discussed with @wpoxon-qci in #228, I adopted this solution https://github.com/Qiskit/qiskit-optimization/issues/228#issuecomment-902022517.

Second issue is about quadratic terms. See the coefficient of the linear term "x@1" in the following example. Note that `x` is represented as `x = 10 + x@0 + 2 * x@1`.

Example
```python
from qiskit_optimization.problems import QuadraticProgram
from qiskit_optimization.converters import IntegerToBinary

qp = QuadraticProgram()
qp.integer_var(10, 13, 'x')
qp.minimize(quadratic={('x', 'x'): 2})

qp2 = IntegerToBinary().convert(qp)
print(qp2)
```

main branch result:
```
\ This file has been generated by DOcplex
\ ENCODING=ISO-8859-1
\Problem name: CPLEX

Minimize
 obj: 40 x@0 + 40 x@1 + [ 4 x@0^2 + 16 x@0*x@1 + 16 x@1^2 ]/2 + 200
Subject To

Bounds
 0 <= x@0 <= 1
 0 <= x@1 <= 1

Binaries
 x@0 x@1
End
```

This PR
```
\ This file has been generated by DOcplex
\ ENCODING=ISO-8859-1
\Problem name: CPLEX

Minimize
 obj: 40 x@0 + 80 x@1 + [ 4 x@0^2 + 16 x@0*x@1 + 16 x@1^2 ]/2 + 200
Subject To

Bounds
 0 <= x@0 <= 1
 0 <= x@1 <= 1

Binaries
 x@0 x@1
End
```

Fixes #227

### Details and comments


