### PR TITLE
Rename runtime programs to clients

### DIFF
--- a/qiskit_optimization/runtime/__init__.py
+++ b/qiskit_optimization/runtime/__init__.py
@@ -25,11 +25,23 @@ algorithms and scripts in the cloud.
 
    VQEProgram
    VQEProgramResult
+   VQERuntimeClient
+   VQERuntimeResult
    QAOAProgram
+   QAOARuntimeClient
 
 """
 
 from .vqe_program import VQEProgram, VQEProgramResult
+from .vqe_runtime_client import VQERuntimeClient, VQERuntimeResult
 from .qaoa_program import QAOAProgram
+from .qaoa_runtime_client import QAOARuntimeClient
 
-__all__ = ["VQEProgram", "VQEProgramResult", "QAOAProgram"]
+__all__ = [
+    "VQEProgram",
+    "VQEProgramResult",
+    "VQERuntimeClient",
+    "VQERuntimeResult",
+    "QAOAProgram",
+    "QAOARuntimeClient",
+]

--- a/qiskit_optimization/runtime/qaoa_program.py
+++ b/qiskit_optimization/runtime/qaoa_program.py
@@ -10,26 +10,29 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""The Qiskit Optimization QAOA Quantum Program."""
+"""The Qiskit Optimization VQE Quantum Program."""
 
 
 from typing import List, Callable, Optional, Any, Dict, Union
+import warnings
 import numpy as np
 
 from qiskit import QuantumCircuit
-from qiskit.algorithms import MinimumEigensolverResult
-from qiskit.algorithms.optimizers import Optimizer
-from qiskit.circuit.library import QAOAAnsatz
-from qiskit.opflow import OperatorBase
 from qiskit.providers import Provider
 from qiskit.providers.backend import Backend
+from qiskit.algorithms import MinimumEigensolverResult
+from qiskit.algorithms.optimizers import Optimizer
+from qiskit.opflow import OperatorBase
 
-from qiskit_optimization.exceptions import QiskitOptimizationError
-from .vqe_program import VQEProgram
+from .qaoa_runtime_client import QAOARuntimeClient
+from .vqe_program import VQEProgramResult
 
 
-class QAOAProgram(VQEProgram):
-    """The Qiskit Optimization QAOA Quantum Program."""
+class QAOAProgram(QAOARuntimeClient):
+    """DEPRECATED. This class has been renamed to ``qiskit_optimization.runtime.VQERuntimeClient``.
+
+    This renaming reflects that this class is a client for a program executed in the cloud.
+    """
 
     def __init__(
         self,
@@ -45,117 +48,51 @@ class QAOAProgram(VQEProgram):
         callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
         store_intermediate: bool = False,
     ) -> None:
-        """
-        Args:
-            optimizer: An optimizer or dictionary specifying a classical optimizer.
-                If a dictionary, only SPSA and QN-SPSA are supported. The dictionary must contain a
-                key ``name`` for the name of the optimizer and may contain additional keys for the
-                settings. E.g. ``{'name': 'SPSA', 'maxiter': 100}``.
-                Per default, SPSA is used.
-            reps: the integer parameter :math:`p` as specified in https://arxiv.org/abs/1411.4028,
-                Has a minimum valid value of 1.
-            initial_state: An optional initial state to prepend the QAOA circuit with
-            mixer: the mixer Hamiltonian to evolve with or a custom quantum circuit. Allows support
-                of optimizations in constrained subspaces as per https://arxiv.org/abs/1709.03489
-                as well as warm-starting the optimization as introduced
-                in http://arxiv.org/abs/2009.10095.
-            initial_point: An optional initial point (i.e. initial parameter values)
-                for the optimizer. If ``None`` a random vector is used.
-            provider: The provider.
-            backend: The backend to run the circuits on.
-            shots: The number of shots to be used
-            measurement_error_mitigation: Whether or not to use measurement error mitigation.
-            callback: a callback that can access the intermediate data during the optimization.
-                Four parameter values are passed to the callback as follows during each evaluation
-                by the optimizer for its current set of parameters as it works towards the minimum.
-                These are: the evaluation count, the optimizer parameters for the
-                ansatz, the evaluated mean and the evaluated standard deviation.
-            store_intermediate: Whether or not to store intermediate values of the optimization
-                steps. Per default False.
-        """
+        warnings.warn(
+            "The qiskit_optimization.runtime.QAOAProgram has been renamed to "
+            "qiskit_optimization.runtime.QAOARuntimeClient to reflect it is a client for a program "
+            "executed in the cloud. The QAOAProgram is deprecated as of Qiskit Nature 0.3.0 and "
+            "be removed no sooner than 3 months after the release date.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
-            ansatz=None,
-            optimizer=optimizer,
-            initial_point=initial_point,
-            provider=provider,
-            backend=backend,
-            shots=shots,
-            measurement_error_mitigation=measurement_error_mitigation,
-            callback=callback,
-            store_intermediate=store_intermediate,
+            optimizer,
+            reps,
+            initial_state,
+            mixer,
+            initial_point,
+            provider,
+            backend,
+            shots,
+            measurement_error_mitigation,
+            callback,
+            store_intermediate,
         )
-        self._initial_state = initial_state
-        self._mixer = mixer
-        self._reps = reps
-
-    @property
-    def ansatz(self) -> Optional[QuantumCircuit]:
-        return self._ansatz
-
-    @ansatz.setter
-    def ansatz(self, ansatz: QuantumCircuit) -> None:
-        raise QiskitOptimizationError(
-            "Cannot set the ansatz for QAOA, it is directly inferred from "
-            "the problem Hamiltonian."
-        )
-
-    @property
-    def initial_state(self) -> Optional[QuantumCircuit]:
-        """
-        Returns:
-            Returns the initial state.
-        """
-        return self._initial_state
-
-    @initial_state.setter
-    def initial_state(self, initial_state: Optional[QuantumCircuit]) -> None:
-        """
-        Args:
-            initial_state: Initial state to set.
-        """
-        self._initial_state = initial_state
-
-    @property
-    def mixer(self) -> Union[QuantumCircuit, OperatorBase]:
-        """
-        Returns:
-            Returns the mixer.
-        """
-        return self._mixer
-
-    @mixer.setter
-    def mixer(self, mixer: Union[QuantumCircuit, OperatorBase]) -> None:
-        """
-        Args:
-            mixer: Mixer to set.
-        """
-        self._mixer = mixer
-
-    @property
-    def reps(self) -> int:
-        """
-        Returns:
-            Returns the reps.
-        """
-        return self._reps
-
-    @reps.setter
-    def reps(self, reps: int) -> None:
-        """
-        Args:
-            reps: The new number of reps.
-        """
-        self._reps = reps
 
     def compute_minimum_eigenvalue(
-        self,
-        operator: OperatorBase,
-        aux_operators: Optional[List[Optional[OperatorBase]]] = None,
+        self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
     ) -> MinimumEigensolverResult:
-        self._ansatz = QAOAAnsatz(
-            operator,
-            reps=self.reps,
-            initial_state=self.initial_state,
-            mixer_operator=self.mixer,
-        )
-        return super().compute_minimum_eigenvalue(operator, aux_operators)
+        result = super().compute_minimum_eigenvalue(operator, aux_operators)
+
+        # convert to previous result type
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            vqe_result = VQEProgramResult()
+
+        for attr in [
+            "job_id",
+            "cost_function_evals",
+            "eigenstate",
+            "eigenvalue",
+            "aux_operator_eigenvalues",
+            "optimal_parameters",
+            "optimal_point",
+            "optimal_value",
+            "optimizer_evals",
+            "optimizer_time",
+            "optimizer_history",
+        ]:
+            setattr(vqe_result, attr, getattr(result, attr))
+
+        return vqe_result

--- a/qiskit_optimization/runtime/qaoa_runtime_client.py
+++ b/qiskit_optimization/runtime/qaoa_runtime_client.py
@@ -1,0 +1,161 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The Qiskit Optimization QAOA Quantum Program."""
+
+
+from typing import List, Callable, Optional, Any, Dict, Union
+import numpy as np
+
+from qiskit import QuantumCircuit
+from qiskit.algorithms import MinimumEigensolverResult
+from qiskit.algorithms.optimizers import Optimizer
+from qiskit.circuit.library import QAOAAnsatz
+from qiskit.opflow import OperatorBase
+from qiskit.providers import Provider
+from qiskit.providers.backend import Backend
+
+from qiskit_optimization.exceptions import QiskitOptimizationError
+from .vqe_runtime_client import VQERuntimeClient
+
+
+class QAOARuntimeClient(VQERuntimeClient):
+    """The Qiskit Optimization QAOA Runtime Client."""
+
+    def __init__(
+        self,
+        optimizer: Optional[Union[Optimizer, Dict[str, Any]]] = None,
+        reps: int = 1,
+        initial_state: Optional[QuantumCircuit] = None,
+        mixer: Union[QuantumCircuit, OperatorBase] = None,
+        initial_point: Optional[np.ndarray] = None,
+        provider: Optional[Provider] = None,
+        backend: Optional[Backend] = None,
+        shots: int = 1024,
+        measurement_error_mitigation: bool = False,
+        callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
+        store_intermediate: bool = False,
+    ) -> None:
+        """
+        Args:
+            optimizer: An optimizer or dictionary specifying a classical optimizer.
+                If a dictionary, only SPSA and QN-SPSA are supported. The dictionary must contain a
+                key ``name`` for the name of the optimizer and may contain additional keys for the
+                settings. E.g. ``{'name': 'SPSA', 'maxiter': 100}``.
+                Per default, SPSA is used.
+            reps: the integer parameter :math:`p` as specified in https://arxiv.org/abs/1411.4028,
+                Has a minimum valid value of 1.
+            initial_state: An optional initial state to prepend the QAOA circuit with
+            mixer: the mixer Hamiltonian to evolve with or a custom quantum circuit. Allows support
+                of optimizations in constrained subspaces as per https://arxiv.org/abs/1709.03489
+                as well as warm-starting the optimization as introduced
+                in http://arxiv.org/abs/2009.10095.
+            initial_point: An optional initial point (i.e. initial parameter values)
+                for the optimizer. If ``None`` a random vector is used.
+            provider: The provider.
+            backend: The backend to run the circuits on.
+            shots: The number of shots to be used
+            measurement_error_mitigation: Whether or not to use measurement error mitigation.
+            callback: a callback that can access the intermediate data during the optimization.
+                Four parameter values are passed to the callback as follows during each evaluation
+                by the optimizer for its current set of parameters as it works towards the minimum.
+                These are: the evaluation count, the optimizer parameters for the
+                ansatz, the evaluated mean and the evaluated standard deviation.
+            store_intermediate: Whether or not to store intermediate values of the optimization
+                steps. Per default False.
+        """
+        super().__init__(
+            ansatz=None,
+            optimizer=optimizer,
+            initial_point=initial_point,
+            provider=provider,
+            backend=backend,
+            shots=shots,
+            measurement_error_mitigation=measurement_error_mitigation,
+            callback=callback,
+            store_intermediate=store_intermediate,
+        )
+        self._initial_state = initial_state
+        self._mixer = mixer
+        self._reps = reps
+
+    @property
+    def ansatz(self) -> Optional[QuantumCircuit]:
+        return self._ansatz
+
+    @ansatz.setter
+    def ansatz(self, ansatz: QuantumCircuit) -> None:
+        raise QiskitOptimizationError(
+            "Cannot set the ansatz for QAOA, it is directly inferred from "
+            "the problem Hamiltonian."
+        )
+
+    @property
+    def initial_state(self) -> Optional[QuantumCircuit]:
+        """
+        Returns:
+            Returns the initial state.
+        """
+        return self._initial_state
+
+    @initial_state.setter
+    def initial_state(self, initial_state: Optional[QuantumCircuit]) -> None:
+        """
+        Args:
+            initial_state: Initial state to set.
+        """
+        self._initial_state = initial_state
+
+    @property
+    def mixer(self) -> Union[QuantumCircuit, OperatorBase]:
+        """
+        Returns:
+            Returns the mixer.
+        """
+        return self._mixer
+
+    @mixer.setter
+    def mixer(self, mixer: Union[QuantumCircuit, OperatorBase]) -> None:
+        """
+        Args:
+            mixer: Mixer to set.
+        """
+        self._mixer = mixer
+
+    @property
+    def reps(self) -> int:
+        """
+        Returns:
+            Returns the reps.
+        """
+        return self._reps
+
+    @reps.setter
+    def reps(self, reps: int) -> None:
+        """
+        Args:
+            reps: The new number of reps.
+        """
+        self._reps = reps
+
+    def compute_minimum_eigenvalue(
+        self,
+        operator: OperatorBase,
+        aux_operators: Optional[List[Optional[OperatorBase]]] = None,
+    ) -> MinimumEigensolverResult:
+        self._ansatz = QAOAAnsatz(
+            operator,
+            reps=self.reps,
+            initial_state=self.initial_state,
+            mixer_operator=self.mixer,
+        )
+        return super().compute_minimum_eigenvalue(operator, aux_operators)

--- a/qiskit_optimization/runtime/vqe_program.py
+++ b/qiskit_optimization/runtime/vqe_program.py
@@ -14,23 +14,23 @@
 
 
 from typing import List, Callable, Optional, Any, Dict, Union
+import warnings
 import numpy as np
 
 from qiskit import QuantumCircuit
-from qiskit.exceptions import QiskitError
 from qiskit.providers import Provider
 from qiskit.providers.backend import Backend
-from qiskit.algorithms import MinimumEigensolver, MinimumEigensolverResult, VQEResult
-from qiskit.algorithms.optimizers import Optimizer, SPSA
-from qiskit.opflow import OperatorBase, PauliSumOp
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.algorithms import MinimumEigensolverResult
+from qiskit.algorithms.optimizers import Optimizer
+from qiskit.opflow import OperatorBase
+
+from .vqe_runtime_client import VQERuntimeClient, VQERuntimeResult
 
 
-class VQEProgram(MinimumEigensolver):
-    """The Qiskit Optimization VQE Quantum Program to call the VQE runtime as a MinimumEigensolver.
+class VQEProgram(VQERuntimeClient):
+    """DEPRECATED. This class has been renamed to ``qiskit_optimization.runtime.VQERuntimeClient``.
 
-    This program is equivalent to the ``VQEProgram`` in Qiskit Nature, but here also serves as basis
-    for the Qiskit Optimization's ``QAOAProgram``.
+    This renaming reflects that this class is a client for a program executed in the cloud.
     """
 
     def __init__(
@@ -45,262 +45,56 @@ class VQEProgram(MinimumEigensolver):
         callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
         store_intermediate: bool = False,
     ) -> None:
-        """
-        Args:
-            ansatz: A parameterized circuit used as Ansatz for the wave function.
-            optimizer: An optimizer or dictionary specifying a classical optimizer.
-                If a dictionary, only SPSA and QN-SPSA are supported. The dictionary must contain a
-                key ``name`` for the name of the optimizer and may contain additional keys for the
-                settings. E.g. ``{'name': 'SPSA', 'maxiter': 100}``.
-                Per default, SPSA is used.
-            backend: The backend to run the circuits on.
-            initial_point: An optional initial point (i.e. initial parameter values)
-                for the optimizer. If ``None`` a random vector is used.
-            shots: The number of shots to be used
-            measurement_error_mitigation: Whether or not to use measurement error mitigation.
-            callback: a callback that can access the intermediate data during the optimization.
-                Four parameter values are passed to the callback as follows during each evaluation
-                by the optimizer for its current set of parameters as it works towards the minimum.
-                These are: the evaluation count, the optimizer parameters for the
-                ansatz, the evaluated mean and the evaluated standard deviation.
-            store_intermediate: Whether or not to store intermediate values of the optimization
-                steps. Per default False.
-        """
-        if optimizer is None:
-            optimizer = SPSA(maxiter=300)
-
-        # define program name
-        self._program_id = "vqe"
-
-        # store settings
-        self._provider = None
-        self._ansatz = ansatz
-        self._optimizer = None
-        self._backend = backend
-        self._initial_point = initial_point
-        self._shots = shots
-        self._measurement_error_mitigation = measurement_error_mitigation
-        self._callback = callback
-        self._store_intermediate = store_intermediate
-
-        # use setter to check for valid inputs
-        if provider is not None:
-            self.provider = provider
-
-        self.optimizer = optimizer
-
-    @property
-    def provider(self) -> Optional[Provider]:
-        """Return the provider."""
-        return self._provider
-
-    @provider.setter
-    def provider(self, provider: Provider) -> None:
-        """Set the provider. Must be a provider that supports the runtime feature."""
-        try:
-            _ = hasattr(provider, "runtime")
-        except QiskitError:
-            # pylint: disable=raise-missing-from
-            raise ValueError(f"The provider {provider} does not provide a runtime environment.")
-
-        self._provider = provider
-
-    @property
-    def program_id(self) -> str:
-        """Return the program ID."""
-        return self._program_id
-
-    @property
-    def ansatz(self) -> QuantumCircuit:
-        """Return the ansatz."""
-        return self._ansatz
-
-    @ansatz.setter
-    def ansatz(self, ansatz: QuantumCircuit) -> None:
-        """Set the ansatz."""
-        self._ansatz = ansatz
-
-    @property
-    def optimizer(self) -> Union[Optimizer, Dict[str, Any]]:
-        """Return the dictionary describing the optimizer."""
-        return self._optimizer
-
-    @optimizer.setter
-    def optimizer(self, optimizer: Union[Optimizer, Dict[str, Any]]) -> None:
-        """Set the optimizer."""
-        if isinstance(optimizer, Optimizer):
-            self._optimizer = optimizer
-        else:
-            if "name" not in optimizer.keys():
-                raise ValueError(
-                    "The optimizer dictionary must contain a ``name`` key specifying the type "
-                    "of the optimizer."
-                )
-
-            _validate_optimizer_settings(optimizer)
-
-            self._optimizer = optimizer
-
-    @property
-    def backend(self) -> Optional[Backend]:
-        """Returns the backend."""
-        return self._backend
-
-    @backend.setter
-    def backend(self, backend) -> None:
-        """Sets the backend."""
-        self._backend = backend
-
-    @property
-    def initial_point(self) -> Optional[np.ndarray]:
-        """Returns the initial point."""
-        return self._initial_point
-
-    @initial_point.setter
-    def initial_point(self, initial_point: Optional[np.ndarray]) -> None:
-        """Sets the initial point."""
-        self._initial_point = initial_point
-
-    @property
-    def shots(self) -> int:
-        """Return the number of shots."""
-        return self._shots
-
-    @shots.setter
-    def shots(self, shots: int) -> None:
-        """Set the number of shots."""
-        self._shots = shots
-
-    @property
-    def measurement_error_mitigation(self) -> bool:
-        """Returns whether or not to use measurement error mitigation.
-
-        Readout error mitigation is done using a complete measurement fitter with the
-        ``self.shots`` number of shots and re-calibrations every 30 minutes.
-        """
-        return self._measurement_error_mitigation
-
-    @measurement_error_mitigation.setter
-    def measurement_error_mitigation(self, measurement_error_mitigation: bool) -> None:
-        """Whether or not to use readout error mitigation."""
-        self._measurement_error_mitigation = measurement_error_mitigation
-
-    @property
-    def store_intermediate(self) -> bool:
-        """Returns whether or not to store intermediate information of the optimization."""
-        return self._store_intermediate
-
-    @store_intermediate.setter
-    def store_intermediate(self, store: bool) -> None:
-        """Whether or not to store intermediate information of the optimization."""
-        self._store_intermediate = store
-
-    @property
-    def callback(self) -> Callable:
-        """Returns the callback."""
-        return self._callback
-
-    @callback.setter
-    def callback(self, callback: Callable) -> None:
-        """Set the callback."""
-        self._callback = callback
-
-    def _wrap_vqe_callback(self) -> Optional[Callable]:
-        """Wraps and returns the given callback to match the signature of the runtime callback."""
-
-        def wrapped_callback(*args):
-            _, data = args  # first element is the job id
-            iteration_count = data[0]
-            params = data[1]
-            mean = data[2]
-            sigma = data[3]
-            return self._callback(iteration_count, params, mean, sigma)
-
-        # if callback is set, return wrapped callback, else return None
-        if self._callback:
-            return wrapped_callback
-        else:
-            return None
+        warnings.warn(
+            "The qiskit_optimization.runtime.VQEProgram has been renamed to "
+            "qiskit_optimization.runtime.VQERuntimeClient to reflect it is a client for a program "
+            "executed in the cloud. The VQEProgram is deprecated as of Qiskit Nature 0.3.0 and "
+            "be removed no sooner than 3 months after the release date.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            ansatz,
+            optimizer,
+            initial_point,
+            provider,
+            backend,
+            shots,
+            measurement_error_mitigation,
+            callback,
+            store_intermediate,
+        )
 
     def compute_minimum_eigenvalue(
         self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
     ) -> MinimumEigensolverResult:
-        """Calls the VQE Runtime to approximate the ground state of the given operator.
+        result = super().compute_minimum_eigenvalue(operator, aux_operators)
 
-        Args:
-            operator: Qubit operator of the observable
-            aux_operators: Optional list of auxiliary operators to be evaluated with the
-                (approximate) eigenstate of the minimum eigenvalue main result and their expectation
-                values returned. For instance in chemistry these can be dipole operators, total
-                particle count operators so we can get values for these at the ground state.
+        # convert to previous result type
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            vqe_result = VQEProgramResult()
 
-        Returns:
-            MinimumEigensolverResult
-
-        Raises:
-            ValueError: If the backend has not yet been set.
-            ValueError: If the provider has not yet been set.
-            RuntimeError: If the job execution failed.
-
-        """
-        if self.backend is None:
-            raise ValueError("The backend has not been set.")
-
-        if self.provider is None:
-            raise ValueError("The provider has not been set.")
-
-        # try to convert the operators to a PauliSumOp, if it isn't already one
-        operator = _convert_to_paulisumop(operator)
-        if aux_operators is not None:
-            aux_operators = [_convert_to_paulisumop(aux_op) for aux_op in aux_operators]
-
-        # combine the settings with the given operator to runtime inputs
-        inputs = {
-            "operator": operator,
-            "aux_operators": aux_operators,
-            "ansatz": self.ansatz,
-            "optimizer": self.optimizer,
-            "initial_point": self.initial_point,
-            "shots": self.shots,
-            "measurement_error_mitigation": self.measurement_error_mitigation,
-            "store_intermediate": self.store_intermediate,
-        }
-
-        # define runtime options
-        options = {"backend_name": self.backend.name()}
-
-        # send job to runtime and return result
-        job = self.provider.runtime.run(
-            program_id=self.program_id,
-            inputs=inputs,
-            options=options,
-            callback=self._wrap_vqe_callback(),
-        )
-        # print job ID if something goes wrong
-        try:
-            result = job.result()
-        except Exception as exc:
-            raise RuntimeError(f"The job {job.job_id()} failed unexpectedly.") from exc
-
-        # re-build result from serialized return value
-        vqe_result = VQEProgramResult()
-        vqe_result.job_id = job.job_id()
-        vqe_result.cost_function_evals = result.get("cost_function_evals", None)
-        vqe_result.eigenstate = result.get("eigenstate", None)
-        vqe_result.eigenvalue = result.get("eigenvalue", None)
-        vqe_result.aux_operator_eigenvalues = result.get("aux_operator_eigenvalues", None)
-        vqe_result.optimal_parameters = result.get("optimal_parameters", None)
-        vqe_result.optimal_point = result.get("optimal_point", None)
-        vqe_result.optimal_value = result.get("optimal_value", None)
-        vqe_result.optimizer_evals = result.get("optimizer_evals", None)
-        vqe_result.optimizer_time = result.get("optimizer_time", None)
-        vqe_result.optimizer_history = result.get("optimizer_history", None)
+        for attr in [
+            "job_id",
+            "cost_function_evals",
+            "eigenstate",
+            "eigenvalue",
+            "aux_operator_eigenvalues",
+            "optimal_parameters",
+            "optimal_point",
+            "optimal_value",
+            "optimizer_evals",
+            "optimizer_time",
+            "optimizer_history",
+        ]:
+            setattr(vqe_result, attr, getattr(result, attr))
 
         return vqe_result
 
 
-class VQEProgramResult(VQEResult):
-    """The VQEProgram result object.
+class VQEProgramResult(VQERuntimeResult):
+    """DEPRECATED. The ``VQEProgram`` result object has been renamed to ``VQERuntimeResult``.
 
     This result objects contains the same as the VQEResult and additionally the history
     of the optimizer, containing information such as the function and parameter values per step.
@@ -308,74 +102,11 @@ class VQEProgramResult(VQEResult):
 
     def __init__(self) -> None:
         super().__init__()
-        self._job_id = None  # type: str
-        self._optimizer_history = None  # type: Dict[str, Any]
-
-    @property
-    def job_id(self) -> str:
-        """The job ID associated with the VQE runtime job."""
-        return self._job_id
-
-    @job_id.setter
-    def job_id(self, job_id: str) -> None:
-        """Set the job ID associated with the VQE runtime job."""
-        self._job_id = job_id
-
-    @property
-    def optimizer_history(self) -> Optional[Dict[str, Any]]:
-        """The optimizer history."""
-        return self._optimizer_history
-
-    @optimizer_history.setter
-    def optimizer_history(self, history: Dict[str, Any]) -> None:
-        """Set the optimizer history."""
-        self._optimizer_history = history
-
-
-def _validate_optimizer_settings(settings):
-    name = settings.get("name", None)
-    if name not in ["SPSA", "QN-SPSA"]:
-        raise NotImplementedError("Only SPSA and QN-SPSA are currently supported.")
-
-    allowed_settings = [
-        "name",
-        "maxiter",
-        "blocking",
-        "allowed_increase",
-        "trust_region",
-        "learning_rate",
-        "perturbation",
-        "resamplings",
-        "last_avg",
-        "second_order",
-        "hessian_delay",
-        "regularization",
-        "initial_hessian",
-    ]
-
-    if name == "QN-SPSA":
-        allowed_settings.remove("trust_region")
-        allowed_settings.remove("second_order")
-
-    unsupported_args = set(settings.keys()) - set(allowed_settings)
-
-    if len(unsupported_args) > 0:
-        raise ValueError(
-            f"The following settings are unsupported for the {name} optimizer: "
-            f"{unsupported_args}"
+        warnings.warn(
+            "The qiskit_optimization.runtime.VQEProgramResult has been renamed to "
+            "qiskit_optimization.runtime.VQERuntimeResult to reflect it is a result from a runtime "
+            "program. The VQEProgramResult is deprecated as of Qiskit Nature 0.3.0 and "
+            "be removed no sooner than 3 months after the release date.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-
-def _convert_to_paulisumop(operator):
-    """Attempt to convert the operator to a PauliSumOp."""
-    if isinstance(operator, PauliSumOp):
-        return operator
-
-    try:
-        primitive = SparsePauliOp(operator.primitive)
-        return PauliSumOp(primitive, operator.coeff)
-    except Exception as exc:
-        raise ValueError(
-            f"Invalid type of the operator {type(operator)} "
-            "must be PauliSumOp, or castable to one."
-        ) from exc

--- a/qiskit_optimization/runtime/vqe_runtime_client.py
+++ b/qiskit_optimization/runtime/vqe_runtime_client.py
@@ -1,0 +1,386 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The Qiskit Optimization VQE Quantum Program."""
+
+
+from typing import List, Callable, Optional, Any, Dict, Union
+import numpy as np
+
+from qiskit import QuantumCircuit
+from qiskit.exceptions import QiskitError
+from qiskit.providers import Provider
+from qiskit.providers.backend import Backend
+from qiskit.algorithms import MinimumEigensolver, MinimumEigensolverResult, VQEResult
+from qiskit.algorithms.optimizers import Optimizer, SPSA
+from qiskit.opflow import OperatorBase, PauliSumOp
+from qiskit.quantum_info import SparsePauliOp
+
+
+class VQERuntimeClient(MinimumEigensolver):
+    """The Qiskit Optimization VQE Runtime Client to call the VQE runtime as a MinimumEigensolver.
+
+    This program is equivalent to the ``VQERuntimeClient`` in Qiskit Nature, but here also serves as
+    basis for the Qiskit Optimization's ``QAOARuntimeClient``.
+    """
+
+    def __init__(
+        self,
+        ansatz: QuantumCircuit,
+        optimizer: Optional[Union[Optimizer, Dict[str, Any]]] = None,
+        initial_point: Optional[np.ndarray] = None,
+        provider: Optional[Provider] = None,
+        backend: Optional[Backend] = None,
+        shots: int = 1024,
+        measurement_error_mitigation: bool = False,
+        callback: Optional[Callable[[int, np.ndarray, float, float], None]] = None,
+        store_intermediate: bool = False,
+    ) -> None:
+        """
+        Args:
+            ansatz: A parameterized circuit used as Ansatz for the wave function.
+            optimizer: An optimizer or dictionary specifying a classical optimizer.
+                If a dictionary, only SPSA and QN-SPSA are supported. The dictionary must contain a
+                key ``name`` for the name of the optimizer and may contain additional keys for the
+                settings. E.g. ``{'name': 'SPSA', 'maxiter': 100}``.
+                Per default, SPSA is used.
+            backend: The backend to run the circuits on.
+            initial_point: An optional initial point (i.e. initial parameter values)
+                for the optimizer. If ``None`` a random vector is used.
+            provider: Provider that supports the runtime feature.
+            shots: The number of shots to be used
+            measurement_error_mitigation: Whether or not to use measurement error mitigation.
+            callback: a callback that can access the intermediate data during the optimization.
+                Four parameter values are passed to the callback as follows during each evaluation
+                by the optimizer for its current set of parameters as it works towards the minimum.
+                These are: the evaluation count, the optimizer parameters for the
+                ansatz, the evaluated mean and the evaluated standard deviation.
+            store_intermediate: Whether or not to store intermediate values of the optimization
+                steps. Per default False.
+        """
+        if optimizer is None:
+            optimizer = SPSA(maxiter=300)
+
+        # define program name
+        self._program_id = "vqe"
+
+        # store settings
+        self._provider = None
+        self._ansatz = ansatz
+        self._optimizer = None
+        self._backend = backend
+        self._initial_point = initial_point
+        self._shots = shots
+        self._measurement_error_mitigation = measurement_error_mitigation
+        self._callback = callback
+        self._store_intermediate = store_intermediate
+
+        # use setter to check for valid inputs
+        if provider is not None:
+            self.provider = provider
+
+        self.optimizer = optimizer
+
+    @property
+    def provider(self) -> Optional[Provider]:
+        """Return the provider."""
+        return self._provider
+
+    @provider.setter
+    def provider(self, provider: Provider) -> None:
+        """Set the provider. Must be a provider that supports the runtime feature."""
+        try:
+            _ = hasattr(provider, "runtime")
+        except QiskitError:
+            # pylint: disable=raise-missing-from
+            raise ValueError(f"The provider {provider} does not provide a runtime environment.")
+
+        self._provider = provider
+
+    @property
+    def program_id(self) -> str:
+        """Return the program ID."""
+        return self._program_id
+
+    @classmethod
+    def supports_aux_operators(cls) -> bool:
+        return True
+
+    @property
+    def ansatz(self) -> QuantumCircuit:
+        """Return the ansatz."""
+        return self._ansatz
+
+    @ansatz.setter
+    def ansatz(self, ansatz: QuantumCircuit) -> None:
+        """Set the ansatz."""
+        self._ansatz = ansatz
+
+    @property
+    def optimizer(self) -> Union[Optimizer, Dict[str, Any]]:
+        """Return the dictionary describing the optimizer."""
+        return self._optimizer
+
+    @optimizer.setter
+    def optimizer(self, optimizer: Union[Optimizer, Dict[str, Any]]) -> None:
+        """Set the optimizer."""
+        if isinstance(optimizer, Optimizer):
+            self._optimizer = optimizer
+        else:
+            if "name" not in optimizer.keys():
+                raise ValueError(
+                    "The optimizer dictionary must contain a ``name`` key specifying the type "
+                    "of the optimizer."
+                )
+
+            _validate_optimizer_settings(optimizer)
+
+            self._optimizer = optimizer
+
+    @property
+    def backend(self) -> Optional[Backend]:
+        """Returns the backend."""
+        return self._backend
+
+    @backend.setter
+    def backend(self, backend) -> None:
+        """Sets the backend."""
+        self._backend = backend
+
+    @property
+    def initial_point(self) -> Optional[np.ndarray]:
+        """Returns the initial point."""
+        return self._initial_point
+
+    @initial_point.setter
+    def initial_point(self, initial_point: Optional[np.ndarray]) -> None:
+        """Sets the initial point."""
+        self._initial_point = initial_point
+
+    @property
+    def shots(self) -> int:
+        """Return the number of shots."""
+        return self._shots
+
+    @shots.setter
+    def shots(self, shots: int) -> None:
+        """Set the number of shots."""
+        self._shots = shots
+
+    @property
+    def measurement_error_mitigation(self) -> bool:
+        """Returns whether or not to use measurement error mitigation.
+
+        Readout error mitigation is done using a complete measurement fitter with the
+        ``self.shots`` number of shots and re-calibrations every 30 minutes.
+        """
+        return self._measurement_error_mitigation
+
+    @measurement_error_mitigation.setter
+    def measurement_error_mitigation(self, measurement_error_mitigation: bool) -> None:
+        """Whether or not to use readout error mitigation."""
+        self._measurement_error_mitigation = measurement_error_mitigation
+
+    @property
+    def store_intermediate(self) -> bool:
+        """Returns whether or not to store intermediate information of the optimization."""
+        return self._store_intermediate
+
+    @store_intermediate.setter
+    def store_intermediate(self, store: bool) -> None:
+        """Whether or not to store intermediate information of the optimization."""
+        self._store_intermediate = store
+
+    @property
+    def callback(self) -> Callable:
+        """Returns the callback."""
+        return self._callback
+
+    @callback.setter
+    def callback(self, callback: Callable) -> None:
+        """Set the callback."""
+        self._callback = callback
+
+    def _wrap_vqe_callback(self) -> Optional[Callable]:
+        """Wraps and returns the given callback to match the signature of the runtime callback."""
+
+        def wrapped_callback(*args):
+            _, data = args  # first element is the job id
+            iteration_count = data[0]
+            params = data[1]
+            mean = data[2]
+            sigma = data[3]
+            return self._callback(iteration_count, params, mean, sigma)
+
+        # if callback is set, return wrapped callback, else return None
+        if self._callback:
+            return wrapped_callback
+        else:
+            return None
+
+    def compute_minimum_eigenvalue(
+        self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
+    ) -> MinimumEigensolverResult:
+        """Calls the VQE Runtime to approximate the ground state of the given operator.
+
+        Args:
+            operator: Qubit operator of the observable
+            aux_operators: Optional list of auxiliary operators to be evaluated with the
+                (approximate) eigenstate of the minimum eigenvalue main result and their expectation
+                values returned. For instance in chemistry these can be dipole operators, total
+                particle count operators so we can get values for these at the ground state.
+
+        Returns:
+            MinimumEigensolverResult
+
+        Raises:
+            ValueError: If the backend has not yet been set.
+            ValueError: If the provider has not yet been set.
+            RuntimeError: If the job execution failed.
+
+        """
+        if self.backend is None:
+            raise ValueError("The backend has not been set.")
+
+        if self.provider is None:
+            raise ValueError("The provider has not been set.")
+
+        # try to convert the operators to a PauliSumOp, if it isn't already one
+        operator = _convert_to_paulisumop(operator)
+        if aux_operators is not None:
+            aux_operators = [_convert_to_paulisumop(aux_op) for aux_op in aux_operators]
+
+        # combine the settings with the given operator to runtime inputs
+        inputs = {
+            "operator": operator,
+            "aux_operators": aux_operators,
+            "ansatz": self.ansatz,
+            "optimizer": self.optimizer,
+            "initial_point": self.initial_point,
+            "shots": self.shots,
+            "measurement_error_mitigation": self.measurement_error_mitigation,
+            "store_intermediate": self.store_intermediate,
+        }
+
+        # define runtime options
+        options = {"backend_name": self.backend.name()}
+
+        # send job to runtime and return result
+        job = self.provider.runtime.run(
+            program_id=self.program_id,
+            inputs=inputs,
+            options=options,
+            callback=self._wrap_vqe_callback(),
+        )
+        # print job ID if something goes wrong
+        try:
+            result = job.result()
+        except Exception as exc:
+            raise RuntimeError(f"The job {job.job_id()} failed unexpectedly.") from exc
+
+        # re-build result from serialized return value
+        vqe_result = VQERuntimeResult()
+        vqe_result.job_id = job.job_id()
+        vqe_result.cost_function_evals = result.get("cost_function_evals", None)
+        vqe_result.eigenstate = result.get("eigenstate", None)
+        vqe_result.eigenvalue = result.get("eigenvalue", None)
+        vqe_result.aux_operator_eigenvalues = result.get("aux_operator_eigenvalues", None)
+        vqe_result.optimal_parameters = result.get("optimal_parameters", None)
+        vqe_result.optimal_point = result.get("optimal_point", None)
+        vqe_result.optimal_value = result.get("optimal_value", None)
+        vqe_result.optimizer_evals = result.get("optimizer_evals", None)
+        vqe_result.optimizer_time = result.get("optimizer_time", None)
+        vqe_result.optimizer_history = result.get("optimizer_history", None)
+
+        return vqe_result
+
+
+class VQERuntimeResult(VQEResult):
+    """The VQERuntimeClient result object.
+
+    This result objects contains the same as the VQEResult and additionally the history
+    of the optimizer, containing information such as the function and parameter values per step.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._job_id = None  # type: str
+        self._optimizer_history = None  # type: Dict[str, Any]
+
+    @property
+    def job_id(self) -> str:
+        """The job ID associated with the VQE runtime job."""
+        return self._job_id
+
+    @job_id.setter
+    def job_id(self, job_id: str) -> None:
+        """Set the job ID associated with the VQE runtime job."""
+        self._job_id = job_id
+
+    @property
+    def optimizer_history(self) -> Optional[Dict[str, Any]]:
+        """The optimizer history."""
+        return self._optimizer_history
+
+    @optimizer_history.setter
+    def optimizer_history(self, history: Dict[str, Any]) -> None:
+        """Set the optimizer history."""
+        self._optimizer_history = history
+
+
+def _validate_optimizer_settings(settings):
+    name = settings.get("name", None)
+    if name not in ["SPSA", "QN-SPSA"]:
+        raise NotImplementedError("Only SPSA and QN-SPSA are currently supported.")
+
+    allowed_settings = [
+        "name",
+        "maxiter",
+        "blocking",
+        "allowed_increase",
+        "trust_region",
+        "learning_rate",
+        "perturbation",
+        "resamplings",
+        "last_avg",
+        "second_order",
+        "hessian_delay",
+        "regularization",
+        "initial_hessian",
+    ]
+
+    if name == "QN-SPSA":
+        allowed_settings.remove("trust_region")
+        allowed_settings.remove("second_order")
+
+    unsupported_args = set(settings.keys()) - set(allowed_settings)
+
+    if len(unsupported_args) > 0:
+        raise ValueError(
+            f"The following settings are unsupported for the {name} optimizer: "
+            f"{unsupported_args}"
+        )
+
+
+def _convert_to_paulisumop(operator):
+    """Attempt to convert the operator to a PauliSumOp."""
+    if isinstance(operator, PauliSumOp):
+        return operator
+
+    try:
+        primitive = SparsePauliOp(operator.primitive)
+        return PauliSumOp(primitive, operator.coeff)
+    except Exception as exc:
+        raise ValueError(
+            f"Invalid type of the operator {type(operator)} "
+            "must be PauliSumOp, or castable to one."
+        ) from exc

--- a/test/runtime/fake_vqeruntime.py
+++ b/test/runtime/fake_vqeruntime.py
@@ -18,7 +18,7 @@ from qiskit.algorithms.optimizers import Optimizer
 from qiskit.circuit import QuantumCircuit
 from qiskit.opflow import PauliSumOp
 from qiskit.providers import Provider
-from qiskit_optimization.runtime import VQEProgramResult
+from qiskit_optimization.runtime import VQERuntimeResult
 
 
 class FakeVQEJob:
@@ -26,7 +26,7 @@ class FakeVQEJob:
 
     def result(self) -> Dict[str, Any]:
         """Return a VQE result."""
-        result = VQEProgramResult()
+        result = VQERuntimeResult()
         serialized_result = {
             "optimizer_evals": result.optimizer_evals,
             "optimizer_time": result.optimizer_time,

--- a/test/runtime/test_qaoaprogram.py
+++ b/test/runtime/test_qaoaprogram.py
@@ -21,7 +21,7 @@ from qiskit.algorithms.optimizers import COBYLA
 from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.opflow import I, Z
 
-from qiskit_optimization.runtime import QAOAProgram, VQEProgramResult
+from qiskit_optimization.runtime import QAOARuntimeClient, VQERuntimeResult
 
 from .fake_vqeruntime import FakeRuntimeProvider
 
@@ -45,7 +45,7 @@ class TestQAOAProgram(QiskitOptimizationTestCase):
         initial_point = np.random.RandomState(42).random(2 * reps)
         backend = QasmSimulatorPy()
 
-        qaoa = QAOAProgram(
+        qaoa = QAOARuntimeClient(
             optimizer=optimizer,
             reps=reps,
             initial_point=initial_point,
@@ -54,7 +54,7 @@ class TestQAOAProgram(QiskitOptimizationTestCase):
         )
         result = qaoa.compute_minimum_eigenvalue(operator)
 
-        self.assertIsInstance(result, VQEProgramResult)
+        self.assertIsInstance(result, VQERuntimeResult)
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_vqeprogram.py
+++ b/test/runtime/test_vqeprogram.py
@@ -22,7 +22,7 @@ from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.opflow import I, Z
 
-from qiskit_optimization.runtime import VQEProgram, VQEProgramResult
+from qiskit_optimization.runtime import VQERuntimeClient, VQERuntimeResult
 
 from .fake_vqeruntime import FakeRuntimeProvider
 
@@ -46,7 +46,7 @@ class TestVQEProgram(QiskitOptimizationTestCase):
         initial_point = np.random.RandomState(42).random(circuit.num_parameters)
         backend = QasmSimulatorPy()
 
-        vqe = VQEProgram(
+        vqe = VQERuntimeClient(
             ansatz=circuit,
             optimizer=optimizer,
             initial_point=initial_point,
@@ -55,7 +55,7 @@ class TestVQEProgram(QiskitOptimizationTestCase):
         )
         result = vqe.compute_minimum_eigenvalue(operator)
 
-        self.assertIsInstance(result, VQEProgramResult)
+        self.assertIsInstance(result, VQERuntimeResult)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the context of Qiskit Runtime, there's been a lot of confusion about what is considered a "runtime program" or "runtime script". To clear this confusion up, we rename the algorithm classes that remotely call the code on the runtime servers to _clients_ and the code on the runtime can be referred to as _program_.

We chose the word client since that's what they are: an API integrated into the algorithm flow that defers the algorithm call to the cloud.

Analogous to Qiskit/qiskit-nature#351.

### Details and comments

The diff might show a lot below, but it was just a renaming of the `VQE(QAOA)Program` to `VQE(QAOA)RuntimeClient` and no internal methods have been touched. 

We could also just call it `VQEClient` for brevity, if that's preferred 🙂 

