### PR TITLE
Duck-type VQE interim results

### DIFF
--- a/qiskit_optimization/runtime/vqe_program.py
+++ b/qiskit_optimization/runtime/vqe_program.py
@@ -197,7 +197,7 @@ class VQEProgram(MinimumEigensolver):
 
     @property
     def callback(self) -> Callable[[int, np.ndarray, float, float], None]:
-        """Returns the call:back."""
+        """Returns the callback."""
         return self._callback
 
     @callback.setter

--- a/qiskit_optimization/runtime/vqe_program.py
+++ b/qiskit_optimization/runtime/vqe_program.py
@@ -196,25 +196,28 @@ class VQEProgram(MinimumEigensolver):
         self._store_intermediate = store
 
     @property
-    def callback(self) -> Callable:
-        """Returns the callback."""
+    def callback(self) -> Callable[[int, np.ndarray, float, float], None]:
+        """Returns the call:back."""
         return self._callback
 
     @callback.setter
-    def callback(self, callback: Callable) -> None:
+    def callback(self, callback: Callable[[int, np.ndarray, float, float], None]) -> None:
         """Set the callback."""
         self._callback = callback
 
-    def _wrap_vqe_callback(self) -> Optional[Callable]:
+    def _wrap_vqe_callback(self) -> Optional[Callable[[int, np.ndarray, float, float], None]]:
         """Wraps and returns the given callback to match the signature of the runtime callback."""
 
         def wrapped_callback(*args):
             _, data = args  # first element is the job id
+            if isinstance(data, dict):
+                return  # unexpected params. skip
             iteration_count = data[0]
             params = data[1]
             mean = data[2]
             sigma = data[3]
-            return self._callback(iteration_count, params, mean, sigma)
+            self._callback(iteration_count, params, mean, sigma)
+            return
 
         # if callback is set, return wrapped callback, else return None
         if self._callback:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add a check for the type of data expected in the callback wraper in VQEProgram.

This will allow us to close Qiskit-Partners/qiskit-runtime#38

### Details and comments

Anticipating changes in the Qiskit Runtime API which will start emitting final results in the WebSocket stream. When that happens, if we don't duck-type in the VQE callback wrapper receiving the interim results, it will get a ValueError exception.

Already done in Qiskit/qiskit-nature#350