### PR TITLE
Fixing the translations script that was breaking the translated docs publish build

### DIFF
--- a/tools/deploy_translatable_strings.sh
+++ b/tools/deploy_translatable_strings.sh
@@ -75,6 +75,7 @@ cp -r $SOURCE_DIR/$DOC_DIR_PO/ optimization/docs
 cp $SOURCE_DIR/setup.py optimization/.
 cp $SOURCE_DIR/requirements-dev.txt optimization/.
 cp $SOURCE_DIR/requirements.txt optimization/.
+cp $SOURCE_DIR/README.md optimization/.
 cp $SOURCE_DIR/qiskit_optimization/VERSION.txt optimization/qiskit_optimization/.
 
 # git checkout translationDocs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The optimization docs build was failing https://github.com/qiskit-community/qiskit-translations/runs/3733340557#step:4:44 recently. The changes made in the PR - https://github.com/Qiskit/qiskit-optimization/pull/247 has added README.md file a dependency that has to be copied over to the translations repo for the build to work.

### Details and comments


