### PR TITLE
Fix application class docstrings for Sphinx formatting

### DIFF
--- a/qiskit_optimization/applications/clique.py
+++ b/qiskit_optimization/applications/clique.py
@@ -28,7 +28,8 @@ class Clique(GraphOptimizationApplication):
 
     References:
         [1]: "Clique (graph theory)",
-        https://en.wikipedia.org/wiki/Clique_(graph_theory)
+        `https://en.wikipedia.org/wiki/Clique_(graph_theory)
+        <https://en.wikipedia.org/wiki/Clique_(graph_theory)>`_
     """
 
     def __init__(
@@ -36,10 +37,11 @@ class Clique(GraphOptimizationApplication):
     ) -> None:
         """
         Args:
-            graph: A graph representing a clique problem. It can be specified directly as a
-            NetworkX Graph, or as an array or list if format suitable to build out a NetworkX graph.
-            size: The size of the clique. When it's None, this class makes an optimization model for
-            a maximal clique instead of the specified size of a clique.
+            graph: A graph representing a problem. It can be specified directly as a
+                `NetworkX <https://networkx.org/>`_ graph,
+                or as an array or list format suitable to build out a NetworkX graph.
+            size: The size of the clique. When it's `None`, the default, this class makes an
+                optimization model for a maximal clique instead of the specified size of a clique.
         """
         super().__init__(graph)
         self._size = size
@@ -105,19 +107,19 @@ class Clique(GraphOptimizationApplication):
         return ["r" if x[node] else "darkgrey" for node in self._graph.nodes]
 
     @property
-    def size(self) -> int:
+    def size(self) -> Optional[int]:
         """Getter of size
 
         Returns:
-            The size of the clique
+            The size of the clique, `None` when maximal clique
         """
         return self._size
 
     @size.setter
-    def size(self, size: int) -> None:
+    def size(self, size: Optional[int]) -> None:
         """Setter of size
 
         Args:
-            size: The size of the clique
+            size: The size of the clique, `None` for maximal clique
         """
         self._size = size

--- a/qiskit_optimization/applications/graph_optimization_application.py
+++ b/qiskit_optimization/applications/graph_optimization_application.py
@@ -40,7 +40,8 @@ class GraphOptimizationApplication(OptimizationApplication):
         """
         Args:
             graph: A graph representing a problem. It can be specified directly as a
-            NetworkX Graph, or as an array or list if format suitable to build out a NetworkX graph.
+                `NetworkX <https://networkx.org/>`_ graph,
+                or as an array or list format suitable to build out a NetworkX graph.
         """
         # The view of the graph is stored which means the graph can not be changed.
         self._graph = nx.Graph(graph).copy(as_view=True)

--- a/qiskit_optimization/applications/stable_set.py
+++ b/qiskit_optimization/applications/stable_set.py
@@ -29,7 +29,8 @@ class StableSet(GraphOptimizationApplication):
 
     References:
         [1]: "Independent set (graph theory)",
-        https://en.wikipedia.org/wiki/Independent_set_(graph_theory)
+        `https://en.wikipedia.org/wiki/Independent_set_(graph_theory)
+        <https://en.wikipedia.org/wiki/Independent_set_(graph_theory)>`_
     """
 
     def to_quadratic_program(self) -> QuadraticProgram:

--- a/qiskit_optimization/applications/tsp.py
+++ b/qiskit_optimization/applications/tsp.py
@@ -31,7 +31,7 @@ class Tsp(GraphOptimizationApplication):
 
     References:
         [1]: "Travelling salesman problem",
-             https://en.wikipedia.org/wiki/Travelling_salesman_problem
+        https://en.wikipedia.org/wiki/Travelling_salesman_problem
     """
 
     def to_quadratic_program(self) -> QuadraticProgram:

--- a/qiskit_optimization/applications/vehicle_routing.py
+++ b/qiskit_optimization/applications/vehicle_routing.py
@@ -41,9 +41,9 @@ class VehicleRouting(GraphOptimizationApplication):
     ) -> None:
         """
         Args:
-            graph: A graph representing a vehicle routing problem. It can be specified directly as a
-            NetworkX Graph, or as an array or list if format suitable to build out a ``NetworkX``
-            graph.
+            graph: A graph representing a problem. It can be specified directly as a
+                `NetworkX <https://networkx.org/>`_ graph,
+                or as an array or list format suitable to build out a NetworkX graph.
             num_vehicles: The number of vehicles
             depot: The index of the depot node where all the vehicle depart
         """


### PR DESCRIPTION
When referring someone to new StableSet documentation I noticed the args were not formatted correctly and the hyperlink did not work - the trailing ) ends up not being part of the resultant link.

![image](https://user-images.githubusercontent.com/40241007/137551139-0f297979-3dff-4287-bc86-0e86f15f04e1.png)

For the link I changed from directly having the link there to the \`text \<link\>\`_ format, which works though is a bit more verbose. I did not see a simpler solution.

I noticed similar format errors on other application pages so fixed those accordingly too. Also for Clique it has an optional size which defaults to None that the getter directly passed back but the typehint did not include Optional so I added that. I also added the same typehint to the setter, since it did not prevent it before and setting it to None allows you to go back to Maximal clique if you had previosuly set a size so it seemed reasonable to show that in the typehint and I amended the docstring just to note this aspect on the getter/setter.





