### PR TITLE
Temporary Remove Python 3.6 from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         include:
           - os: macos-latest
             python-version: 3.8
@@ -285,10 +285,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/download-artifact@v2
         with:
-          name:  ubuntu-latest-3.6
-          path: /tmp/o36
-      - uses: actions/download-artifact@v2
-        with:
           name:  ubuntu-latest-3.7
           path: /tmp/o37
       - uses: actions/download-artifact@v2
@@ -312,7 +308,7 @@ jobs:
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/o36/opt.dep /tmp/o37/opt.dep /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/m38/opt.dep /tmp/w38/opt.dep || true
+          sort -f -u /tmp/o37/opt.dep /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/m38/opt.dep /tmp/w38/opt.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/o37/opt.dat


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Terra 0.20 removed python 3.6 support. Since we cannot do it in the main branch until we release 0.3.0, I am temporarily removing it from the CI. After release I will have to put it back on the branch stable/0.3 and then python 3.6 support will be definitely removed from main.


### Details and comments


