### PR TITLE
Perform minor updates to tutorials/02_converters_for_quadratic_programs

### DIFF
--- a/docs/tutorials/02_converters_for_quadratic_programs.ipynb
+++ b/docs/tutorials/02_converters_for_quadratic_programs.ipynb
@@ -11,9 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optimization problems in Qiskit's optimization module are represented with the `QuadraticProgram` class, which is generic and powerful representation for optimization problems. In general, optimization algorithms are defined for a certain formulation of a quadratic program and we need to convert our problem to the right type.\n",
+    "Optimization problems in Qiskit's optimization module are represented with the `QuadraticProgram` class, which is a generic and powerful representation for optimization problems. In general, optimization algorithms are defined for a certain formulation of a quadratic program, and we need to convert our problem to the right type.\n",
     "\n",
-    "For instance, Qiskit provides several optimization algorithms that can handle Quadratic Unconstrained Binary Optimization (QUBO) problems. These are mapped to Ising Hamiltonians, for which Qiskit uses the `qiskit.aqua.operators` module, and then their ground state is approximated. For this optimization commonly known algorithms such as VQE or QAOA can be used as underlying routine. See the following tutorial about the [Minimum Eigen Optimizer](./03_minimum_eigen_optimizer.ipynb) for more detail. Note that also other algorithms exist that work differently, such as the `GroverOptimizer`.\n",
+    "For instance, Qiskit provides several optimization algorithms that can handle [Quadratic Unconstrained Binary Optimization](https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization) (QUBO) problems. These are mapped to Ising Hamiltonians, for which Qiskit uses the `qiskit.opflow` module, and then their ground state is approximated. For this optimization, commonly known algorithms such as VQE or QAOA can be used as underlying routine. See the following tutorial about the [Minimum Eigen Optimizer](./03_minimum_eigen_optimizer.ipynb) for more detail. Note that also other algorithms exist that work differently, such as the `GroverOptimizer`.\n",
     "\n",
     "To map a problem to the correct input format, the optimization module of Qiskit offers a variety of converters. In this tutorial we're providing an overview on this functionality. Currently, Qiskit contains the following converters.\n",
     "\n",
@@ -166,9 +166,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After converting, the formulation of the problem looks like as the follows. As we can see, the inequality constraints are replaced with equality constraints with additional integer slack variables, $xyz\\_leg\\text{@}int\\_slack$ and $xyz\\_geq\\text{@}int\\_slack$. \n",
+    "After converting, the formulation of the problem looks like the above output. As we can see, the inequality constraints are replaced with equality constraints with additional integer slack variables, $xyz\\_leg\\text{@}int\\_slack$ and $xyz\\_geq\\text{@}int\\_slack$. \n",
     "\n",
-    "Let us explain how the conversion works. For example, the lower bound of the left side of the first constraint is $0$ which is the case of $x=0$, $y=0$, and $z=0$. Thus, the upperbound of the additional integer variable must be $5$ to be able to satisfy even the case of $x=0$, $y=0$, and $z=0$. Note that we cut off the part after the decimal point in the converted formulation since the left side of the first constraint in the original formulation can be only integer values. For the second constraint, basically we apply the same approach. However, the symbol in the second constraint is $\\geq$, so we add minus before $xyz\\_geq\\text{@}int\\_slack$ to be able to satisfy even the case of $x=1, y=1$, and $z=7$.\n",
+    "Let us explain how the conversion works. For example, the lower bound of the left side of the first constraint is $0$ which is the case of $x=0$, $y=0$, and $z=0$. Thus, the upper bound of the additional integer variable must be $5$ to be able to satisfy even the case of $x=0$, $y=0$, and $z=0$. Note that we cut off the part after the decimal point in the converted formulation since the left side of the first constraint in the original formulation can be only integer values. For the second constraint, basically we apply the same approach. However, the symbol in the second constraint is $\\geq$, so we add minus before $xyz\\_geq\\text{@}int\\_slack$ to be able to satisfy even the case of $x=1, y=1$, and $z=7$.\n",
     "\n",
     "\\begin{aligned}\n",
     "   & \\text{maximize}\n",
@@ -199,7 +199,7 @@
    "source": [
     "`IntegerToBinary` converts integer variables into binary variables and coefficients to remove integer variables from `QuadraticProgram`. For converting, bounded-coefficient encoding proposed in [arxiv:1706.01945](https://arxiv.org/abs/1706.01945) (Eq. (5)) is used. For more detail of the encoding method, please see the paper.\n",
     "\n",
-    "We use the output of `InequalityToEquality` as starting point. Variable $x$ and $y$ are binary variables, while the variable $z$ and the slack variables $xyz\\_leq\\text{@}int\\_slack$ and $xyz\\_geq\\text{@}int\\_slack$ are integer variables. We print the problem again for reference."
+    "We use the output of `InequalityToEquality` as a starting point. Variables $x$ and $y$ are binary variables, while the variable $z$ and the slack variables $xyz\\_leq\\text{@}int\\_slack$ and $xyz\\_geq\\text{@}int\\_slack$ are integer variables. We print the problem again for reference."
    ]
   },
   {
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After converting, integer variables $z$ is replaced with three binary variables $z\\text{@}0$, $z\\text{@}1$ and $z\\text{@}2$ with coefficients 1, 2 and 4, respectively as the above. \n",
+    "After converting, the integer variable $z$ is replaced with three binary variables $z\\text{@}0$, $z\\text{@}1$ and $z\\text{@}2$ with coefficients 1, 2 and 4, respectively as the above. \n",
     "The slack variables $xyz\\_leq\\text{@}int\\_slack$ and $xyz\\_geq\\text{@}int\\_slack$ that were introduced by `InequalityToEquality` are also both replaced with three binary variables with coefficients 1, 2, 2, and  1, 2, 3, respectively.\n",
     "\n",
     "Note: Essentially the coefficients mean that the sum of these binary variables with coefficients can be the sum of a subset of $\\{1, 2, 4\\}$, $\\{1, 2, 2\\}$, and $\\{1, 2, 3\\}$ to represent that acceptable values $\\{0, \\ldots, 7\\}$, $\\{0, \\ldots, 5\\}$, and $\\{0, \\ldots, 6\\}$, which respects the lower bound and the upper bound of original integer variables correctly.\n",
@@ -337,7 +337,7 @@
     "An input to the converter has to be a `QuadraticProgram` with only linear equality constraints. Those equality constraints, e.g. $\\sum_i a_i x_i  = b$ where $a_i$ and $b$ are numbers and $x_i$ is a variable, will be added to the objective function in the form of $M(b - \\sum_i a_i x_i)^2$ where $M$ is a large number as penalty factor. \n",
     "By default $M= 1e5$. The sign of the term depends on whether the problem type is a maximization or minimization.\n",
     "\n",
-    "We use the output of `IntegerToBinary` as starting point, where all variables are binary variables and all inequality constraints have been mapped to equality constraints. \n",
+    "We use the output of `IntegerToBinary` as a starting point, where all variables are binary variables and all inequality constraints have been mapped to equality constraints. \n",
     "We print the problem again for reference."
    ]
   },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I have made some grammar fixes and a few stylistic changes to the text in `docs/tutorials/02_converters_for_quadratic_programs.ipynb`.

### Details and comments

- I have also added a link to the [QUBO Wikipedia page](https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization).
- Most notably, I replaced the phrase `qiskit.aqua.operators` with `qiskit.opflow`.