### PR TITLE
Add garrison's personal email address to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -36,6 +36,7 @@ Isabel Haide <isabel.haide@ibm.com>
 Jan Müggenburg <jan.mueggenburg@ibm.com> 
 Jan Müggenburg <jan.mueggenburg@ibm.com> <jan@oc6058543760.ibm.com>
 James R. Garrison <garrison@ibm.com>
+James R. Garrison <garrison@ibm.com> <jim@garrison.cc>
 Jay M. Gambetta <jay.gambetta@us.ibm.com>
 Juan Cruz-Benito <juan.cruz@ibm.com>
 Julien Gacon <jul@zurich.ibm.com>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds my personal email address to `.mailmap`~~, so that my name will no longer appear in both forms in `Qiskit.bib`~~.

### Details and comments

~~I figured out why [both forms of my name now appear in `Qiskit.bib`](https://github.com/Qiskit/qiskit/pull/1373#issuecomment-991414722).~~  Even though I used my work email address when creating commits for all pull requests I submitted to qiskit-optimization, those that were merged using mergify[bot] (#292 and #293) were rewritten to use my personal email address, presumably because it is the primary address on my GitHub account.  (Nevertheless, I consider this to be a bug in mergify[bot].)  The ones that were merged manually (#295, #296) have my work email address, as expected.

EDIT: Actually, it looks like #295 was merged by mergify[bot], too.  I am not sure why my email address was not modified in that case.  I am not sure whether it is GitHub or mergify[bot], but something is modifying my email address sometimes when commits are squashed & merged.

- #292: [original commit](https://github.com/Qiskit/qiskit-optimization/pull/292/commits/626c3667d6aeca11e14695667f1ed90b73189889) | [as squashed](https://github.com/Qiskit/qiskit-optimization/commit/699863720eaad6964fa3b7308eba2bc5cb9bfbe7)
- #293: [original commit](https://github.com/Qiskit/qiskit-optimization/pull/293/commits/d24d562691ee471e249bc6cb8e14bda58785aa59) | [as squashed](https://github.com/Qiskit/qiskit-optimization/commit/36aaa0e267e1d722b9872a667018d4ded0e9cfdb)

Also, I have now recalled that [qiskit-optimization isn't even considered when generating `Qiskit.bib`](https://github.com/Qiskit/qiskit-optimization/pull/295#issuecomment-990356594), so I will have to make this same update to `Qiskit/qiskit` for it to take effect in the bib file.