### PR TITLE
Remove unnecessary Union with PauliSumOp

### DIFF
--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_optimization/problems/quadratic_program.py
+++ b/qiskit_optimization/problems/quadratic_program.py
@@ -24,7 +24,7 @@ from numpy import ndarray
 from scipy.sparse import spmatrix
 
 from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit.opflow import OperatorBase, PauliSumOp
+from qiskit.opflow import OperatorBase
 
 from ..exceptions import QiskitOptimizationError
 from ..infinity import INFINITY
@@ -988,7 +988,7 @@ class QuadraticProgram:
 
     def from_ising(
         self,
-        qubit_op: Union[OperatorBase, PauliSumOp],
+        qubit_op: OperatorBase,
         offset: float = 0.0,
         linear: bool = False,
     ) -> None:

--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -115,7 +115,7 @@ def to_ising(quad_prog: QuadraticProgram) -> Tuple[OperatorBase, float]:
 
 
 def from_ising(
-    qubit_op: Union[OperatorBase, PauliSumOp],
+    qubit_op: OperatorBase,
     offset: float = 0.0,
     linear: bool = False,
 ) -> QuadraticProgram:

--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -13,7 +13,7 @@
 """Translator between an Ising Hamiltonian and a quadratic program"""
 
 import math
-from typing import Tuple, Union
+from typing import Tuple
 
 import numpy as np
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This replaces `Union[OperatorBase, PauliSumOp]` with `OperatorBase`, as `PauliSumOp` is a subclass of `OperatorBase`, so the union is redundant.

### Details and comments

I'm proposing this change because I found the union misleading -- I expected that its presence implied that `PauliSumOp` is not part of the `OperatorBase` hierarchy, but that is wrong.  I believe this change makes more sense, but if there is a reason to prefer that `PauliSumOp` be listed explicitly in the `Union`, I am open to learning why.