### PR TITLE
Mention the remaining converters in the converters tutorial

### DIFF
--- a/docs/tutorials/02_converters_for_quadratic_programs.ipynb
+++ b/docs/tutorials/02_converters_for_quadratic_programs.ipynb
@@ -17,10 +17,13 @@
     "\n",
     "To map a problem to the correct input format, the optimization module of Qiskit offers a variety of converters. In this tutorial we're providing an overview on this functionality. Currently, Qiskit contains the following converters.\n",
     "\n",
-    "- `InequalityToEquality`: converts inequality constraints into equality constraints with additional slack variables.\n",
-    "- `IntegerToBinary`: converts integer variables into binary variables and corresponding coefficients. \n",
-    "- `LinearEqualityToPenalty`: convert equality constraints into additional terms of the object function.\n",
-    "- `QuadraticProgramToQubo`: a wrapper for `InequalityToEquality`, `IntegerToBinary`, and `LinearEqualityToPenalty` for convenience."
+    "- `InequalityToEquality`: convert inequality constraints into equality constraints with additional slack variables.\n",
+    "- `IntegerToBinary`: convert integer variables into binary variables and corresponding coefficients.\n",
+    "- `LinearEqualityToPenalty`: convert equality constraints into additional terms of the objective function.\n",
+    "- `LinearInequalityToPenalty`: convert inequality constraints into additional terms of the objective function.\n",
+    "- `MaximizeToMinimize`: convert to the equivalent minimization problem.\n",
+    "- `MinimizeToMaximize`: convert to the equivalent maximization problem.\n",
+    "- `QuadraticProgramToQubo`: a wrapper that includes `InequalityToEquality`, `IntegerToBinary`, `LinearEqualityToPenalty`, `LinearInequalityToPenalty`, and `MaximizeToMinimize` for convenience."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I've added the remaining converters to the tutorial and standardized usage in a few places.  I was motivated to formulate a PR when I realized that `LinearInequalityToPenalty` is not the same thing as `LinearEqualityToPenalty` (it was added later, in #157).

### Details and comments

Per https://github.com/Qiskit/qiskit-optimization/issues/84#issuecomment-1008211844, I'm not sure if it matters the order in which the converters that `QuadraticProgramToQubo` wraps are listed.
