### PR TITLE
Correct the `ADMMOptimizer.get_compatibility_msg` docstring

### DIFF
--- a/qiskit_optimization/algorithms/admm_optimizer.py
+++ b/qiskit_optimization/algorithms/admm_optimizer.py
@@ -247,10 +247,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
             problem: The optimization problem to check compatibility.
 
         Returns:
-            Returns True if the problem is compatible, otherwise raises an error.
-
-        Raises:
-            QiskitOptimizationError: If the problem is not compatible with the ADMM optimizer.
+            Returns the incompatibility message. If the message is empty no issues were found.
         """
 
         msg = ""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes a docstring

### Details and comments

I noticed this incorrect docstring and then looked at the `get_compatibility_msg` docstrings in all the other `algorithms` as well, but in the end this was the only incorrect one. 