### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -105,12 +105,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         include:
           - os: macos-latest
             python-version: 3.8
+          - os: macos-latest
+            python-version: '3.10'
           - os: windows-latest
             python-version: 3.8
+          - os: windows-latest
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -300,18 +304,30 @@ jobs:
           path: /tmp/o39
       - uses: actions/download-artifact@v2
         with:
+          name: ubuntu-latest-3.10
+          path: /tmp/o310
+      - uses: actions/download-artifact@v2
+        with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v2
         with:
+          name: macos-latest-3.10
+          path: /tmp/m310
+      - uses: actions/download-artifact@v2
+        with:
           name: windows-latest-3.8
           path: /tmp/w38
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows-latest-3.10
+          path: /tmp/w310
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/o37/opt.dep /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/m38/opt.dep /tmp/w38/opt.dep || true
+          sort -f -u /tmp/o37/opt.dep /tmp/o38/opt.dep /tmp/o39/opt.dep /tmp/o310/opt.dep /tmp/m38/opt.dep /tmp/m310/opt.dep /tmp/w38/opt.dep tmp/w310/opt.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/o37/opt.dat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39', 'py310']

--- a/releasenotes/notes/add-python310-support-49aa9931cd4dabab.yaml
+++ b/releasenotes/notes/add-python310-support-49aa9931cd4dabab.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Added support for running with Python 3.10. 
+    At the the time of the release, Cplex didn't have a python 3.10 version and
+    Docplex failed inside :func:`docplex.mp.model.Model.binary_var_list`.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -60,6 +60,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering"
     ],
     keywords='qiskit sdk quantum optimization',
@@ -68,7 +69,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     extras_require={
-        'cplex': ["cplex; python_version < '3.9'"],
+        'cplex': ["cplex; python_version < '3.10'"],
         'cvx': ['cvxpy'],
         'matplotlib': ['matplotlib'],
         'gurobi': ['gurobipy'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py37, py38, py39, lint
+envlist = py37, py38, py39, py310, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Following Qiskit/qiskit-terra#7102
Fixes #319
Fixes #321


### Details and comments
There isn't cplex for python 3.10. Keeping the tutorials running under python 3.7 and 3.8

Even though docplex builds and installs on python 3.10, it is not advertised as working in neither python 3.9 nor python 3.10.
The tutorials under python 3.10 fail on docplex. I am keeping the tutorials CI running for python 3.7 and python 3.8 as before.

The failure occurs inside `08_cvar_optimization.ipynb`:
```
# create docplex model
mdl = Model("portfolio_optimization")
x = mdl.binary_var_list("x{}".format(i) for i in range(n))
objective = mdl.sum([mu[i] * x[i] for i in range(n)])
objective -= q * mdl.sum([sigma[i, j] * x[i] * x[j] for i in range(n) for j in range(n)])
mdl.maximize(objective)
mdl.add_constraint(mdl.sum(x[i] for i in range(n)) == budget)

# case to
qp = from_docplex_mp(mdl)
```
```
ImportError                               Traceback (most recent call last)
Input In [5], in <module>
      1 # create docplex model
      2 mdl = Model("portfolio_optimization")
----> 3 x = mdl.binary_var_list("x{}".format(i) for i in range(n))
      4 objective = mdl.sum([mu[i] * x[i] for i in range(n)])
      5 objective -= q * mdl.sum([sigma[i, j] * x[i] * x[j] for i in range(n) for j in range(n)])

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/model.py:2349, in Model.binary_var_list(self, keys, lb, ub, name, key_format)
   2325 def binary_var_list(self, keys, lb=None, ub=None, name=str, key_format=None):
   2326     """ Creates a list of binary decision variables and stores them in the model.
   2327 
   2328     Args:
   (...)
   2347 
   2348     """
-> 2349     return self._var_list(keys, self.binary_vartype, name=name, lb=lb, ub=ub, key_format=key_format)

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/model.py:2316, in Model._var_list(self, keys, vartype, lb, ub, name, key_format)
   2315 def _var_list(self, keys, vartype, lb=None, ub=None, name=str, key_format=None):
-> 2316     return self._lfactory.var_list(keys, vartype, lb, ub, name, key_format)

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/mfactory.py:434, in ModelFactory.var_list(self, keys, vartype, lb, ub, name, key_format, create_container)
    432 if create_container:
    433     ctn = self._new_var_container(vartype, key_list=[fixed_keys], lb=lb, ub=ub, name=name)
--> 434     var_list = self.new_var_list(ctn, fixed_keys, vartype, lb, ub, actual_name, 1, key_format)
    435     ctn._attach_var_list(var_list)
    436 else:

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/mfactory.py:470, in ModelFactory.new_var_list(self, var_container, key_seq, vartype, lb, ub, name, dimension, key_format, _safe_bounds, _safe_names, var_factory_fn, _add_container)
    468     xnames = name or []
    469 else:
--> 470     xnames = self._expand_names(key_seq, name, dimension, key_format)
    472 safe_lbs = _safe_bounds or not xlbs
    473 safe_ubs = _safe_bounds or not xubs

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/mfactory.py:301, in ModelFactory._expand_names(self, keys, user_name, dimension, key_format)
    299 else:
    300     stringifier_ = self._get_stringifier(dimension, keys)
--> 301     actual_naming_fn = compile_naming_function(keys, user_name, dimension, key_format,
    302                                                stringifier=stringifier_)
    303     computed_names = [actual_naming_fn(key) for key in keys]
    304     return computed_names

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/mfactory.py:125, in compile_naming_function(keys, user_name, dimension, key_format, _default_key_format, stringifier)
    121     else:
    122         # here keys are tuples of size >= 2
    123         return lambda key_tuple: fixed_format_string % key_tuple
--> 125 elif is_function(user_name):
    126     return user_name
    128 elif is_iterable(user_name):
    129     # check that the iterable has same len as keys,
    130     # otherwise thereis no more default naming and None cannot appear in CPLEX name arrays

File ~/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/site-packages/docplex/mp/utils.py:220, in is_function(e)
    218     from collections.abc import Callable
    219 else:  # pragma: no cover
--> 220     from collections import Callable  # @UnresolvedImport
    221 return isinstance(e, Callable)

ImportError: cannot import name 'Callable' from 'collections' (/Users/manoel/opt/anaconda3/envs/Qiskitenv310/lib/python3.10/collections/__init__.py)
```

IMPORTANT:
Terra is backporting this. Once they release it to pypi, I will backport it as well. Do not backport before they release otherwise it will fail. The stable CI gets Terra from Pypi.

