### PR TITLE
Fix up to_ising docstring

### DIFF
--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -30,9 +30,12 @@ def to_ising(quad_prog: QuadraticProgram) -> Tuple[OperatorBase, float]:
     i-th variable is mapped to i-th qubit.
     See https://github.com/Qiskit/qiskit-terra/issues/1148 for details.
 
+    Args:
+        quad_prog: The problem to be translated.
+
     Returns:
-        qubit_op: The qubit operator for the problem
-        offset: The constant value in the Ising Hamiltonian.
+        A tuple (qubit_op, offset) comprising the qubit operator for the problem
+        and offset for the constant value in the Ising Hamiltonian.
 
     Raises:
         QiskitOptimizationError: If an integer variable or a continuous variable exists


### PR DESCRIPTION
When referring someone to the `to_ising` method I noticed that the args were not documented and the return was not well formatted. 

![image](https://user-images.githubusercontent.com/40241007/153508320-730156bf-3259-4ee9-b0de-5019e934fbf3.png)

- - - - - -

This PR adds the Args and fixes the return so it now looks like this 

![image](https://user-images.githubusercontent.com/40241007/153508208-268e1ea6-7df5-4300-9b33-a2866c30eb7a.png)



