### PR TITLE
Exclude locale from the sync path

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -26,4 +26,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/optimization
+rclone sync --progress --exclude locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/optimization


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

rclone has to exclude `locale/*` from the sync path otherwise when the docs build are run, it will delete all the contents including that from the locale path.

### Details and comments


