### PR TITLE
Fix `from_ising` with identity terms

### DIFF
--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -185,7 +185,9 @@ def from_ising(
         z_index = np.where(pauli.z)[0]
         num_z = len(z_index)
 
-        if num_z == 1:
+        if num_z == 0:
+            offset += coeff.real
+        elif num_z == 1:
             pauli_coeffs_diag[z_index[0]] = coeff.real
         elif num_z == 2:
             pauli_coeffs_triu[z_index[0], z_index[1]] = coeff.real

--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -112,6 +112,9 @@ def to_ising(quad_prog: QuadraticProgram) -> Tuple[OperatorBase, float]:
     if isinstance(qubit_op, OperatorBase):
         qubit_op = qubit_op.reduce()
     else:
+        # If there is no variable, we set num_nodes=1 so that qubit_op should be an operator.
+        # If num_nodes=0, I^0 = 1 (int).
+        num_nodes = max(1, num_nodes)
         qubit_op = 0 * I ^ num_nodes
 
     return qubit_op, offset

--- a/qiskit_optimization/translators/ising.py
+++ b/qiskit_optimization/translators/ising.py
@@ -112,7 +112,7 @@ def to_ising(quad_prog: QuadraticProgram) -> Tuple[OperatorBase, float]:
     if isinstance(qubit_op, OperatorBase):
         qubit_op = qubit_op.reduce()
     else:
-        qubit_op = I ^ num_nodes
+        qubit_op = 0 * I ^ num_nodes
 
     return qubit_op, offset
 

--- a/releasenotes/notes/fix-ising-9f8803b8a7a7e78b.yaml
+++ b/releasenotes/notes/fix-ising-9f8803b8a7a7e78b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue that :func:`~qiskit_optimization.translators.from_ising`
+    raises an error when Pauli I is given.
+  - |
+    Fixed an issue that :func:`~qiskit_optimization.translators.to_ising`
+    returns a wrong operator when there is no variable in an input problem.

--- a/test/translators/test_ising.py
+++ b/test/translators/test_ising.py
@@ -145,8 +145,47 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
 
     def test_pauli_I_Z(self):
         """test from_ising and to_ising with Pauli I and Z"""
-        with self.subTest("I"):
-            q_p = from_ising(2 * I)
+        with self.subTest("0 * I, linear=False"):
+            q_p = from_ising(0 * I, linear=False)
+            self.assertEqual(q_p.get_num_vars(), 1)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 0)
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, 0)
+
+        with self.subTest("0 * I, linear=True"):
+            q_p = from_ising(0 * I, linear=True)
+            self.assertEqual(q_p.get_num_vars(), 1)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 0)
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, 0)
+
+        with self.subTest("2 * I, linear=False"):
+            q_p = from_ising(2 * I, linear=False)
+            self.assertEqual(q_p.get_num_vars(), 1)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 2)
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, 2)
+
+        with self.subTest("2 * I, linear=True"):
+            q_p = from_ising(2 * I, linear=True)
             self.assertEqual(q_p.get_num_vars(), 1)
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
@@ -184,7 +223,20 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             np.testing.assert_allclose(op.to_matrix(), Z.to_matrix())
             self.assertAlmostEqual(offset, 0)
 
-        with self.subTest("II"):
+        with self.subTest("3 * II, linear=False"):
+            q_p = from_ising(3 * I ^ I)
+            self.assertEqual(q_p.get_num_vars(), 2)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 3)
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((4, 4)))
+            self.assertAlmostEqual(offset, 3)
+
+        with self.subTest("3 * II, linear=True"):
             q_p = from_ising(3 * I ^ I)
             self.assertEqual(q_p.get_num_vars(), 2)
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
@@ -222,3 +274,25 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             op, offset = to_ising(q_p)
             np.testing.assert_allclose(op.to_matrix(), (I ^ Z).to_matrix())
             self.assertAlmostEqual(offset, 0)
+
+    def test_to_ising_wo_variable(self):
+        """test to_ising with problems without variables"""
+        with self.subTest("empty problem"):
+            q_p = QuadraticProgram()
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, 0)
+
+        with self.subTest("min 3"):
+            q_p = QuadraticProgram()
+            q_p.minimize(constant=3)
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, 3)
+
+        with self.subTest("max -1"):
+            q_p = QuadraticProgram()
+            q_p.minimize(constant=-1)
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, -1)

--- a/test/translators/test_ising.py
+++ b/test/translators/test_ising.py
@@ -292,7 +292,7 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
 
         with self.subTest("max -1"):
             q_p = QuadraticProgram()
-            q_p.minimize(constant=-1)
+            q_p.maximize(constant=-1)
             op, offset = to_ising(q_p)
             np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
-            self.assertAlmostEqual(offset, -1)
+            self.assertAlmostEqual(offset, 1)

--- a/test/translators/test_ising.py
+++ b/test/translators/test_ising.py
@@ -37,7 +37,7 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             q_p.minimize(linear={"x": 1}, quadratic={("x", "y"): 1})
             op, offset = to_ising(q_p)
             op_ref = PauliSumOp.from_list([("ZI", -0.25), ("IZ", -0.75), ("ZZ", 0.25)])
-            np.testing.assert_array_almost_equal(op.to_matrix(), op_ref.to_matrix())
+            np.testing.assert_allclose(op.to_matrix(), op_ref.to_matrix())
             self.assertAlmostEqual(offset, 0.75)
 
         with self.subTest("maximize"):
@@ -49,7 +49,7 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             q_p.maximize(linear={"x": 1}, quadratic={("x", "y"): 1})
             op, offset = to_ising(q_p)
             op_ref = PauliSumOp.from_list([("ZI", 0.25), ("IZ", 0.75), ("ZZ", -0.25)])
-            np.testing.assert_array_almost_equal(op.to_matrix(), op_ref.to_matrix())
+            np.testing.assert_allclose(op.to_matrix(), op_ref.to_matrix())
             self.assertAlmostEqual(offset, -0.75)
 
     def test_to_ising2(self):
@@ -64,7 +64,7 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             q_p.minimize(constant=1, linear={"x": -2, "y": -2}, quadratic={("x", "y"): 4})
             op, offset = to_ising(q_p)
             op_ref = PauliSumOp.from_list([("ZZ", 1.0)])
-            np.testing.assert_array_almost_equal(op.to_matrix(), op_ref.to_matrix())
+            np.testing.assert_allclose(op.to_matrix(), op_ref.to_matrix())
             self.assertAlmostEqual(offset, 0.0)
 
         with self.subTest("maximize"):
@@ -76,7 +76,7 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             q_p.maximize(constant=1, linear={"x": -2, "y": -2}, quadratic={("x", "y"): 4})
             op, offset = to_ising(q_p)
             op_ref = PauliSumOp.from_list([("ZZ", -1.0)])
-            np.testing.assert_array_almost_equal(op.to_matrix(), op_ref.to_matrix())
+            np.testing.assert_allclose(op.to_matrix(), op_ref.to_matrix())
             self.assertAlmostEqual(offset, 0.0)
 
     def test_from_ising(self):
@@ -90,10 +90,8 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 0)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [1, 0])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[0, 1], [0, 0]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [1, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0, 1], [0, 0]])
 
         with self.subTest("linear: False"):
             q_p = from_ising(op, 0.75, linear=False)
@@ -101,10 +99,8 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 0)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0, 0])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[1, 1], [0, 0]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[1, 1], [0, 0]])
 
     def test_from_ising2(self):
         """test to_from_ising 2"""
@@ -117,10 +113,8 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 1)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [-2, -2])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[0, 4], [0, 0]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [-2, -2])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0, 4], [0, 0]])
 
         with self.subTest("linear: False"):
             q_p = from_ising(op, 0, linear=False)
@@ -128,10 +122,8 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 1)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0, 0])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[-2, 4], [0, -2]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[-2, 4], [0, -2]])
 
     def test_from_ising_pauli_with_invalid_paulis(self):
         """test to_from_ising with invalid Pauli terms"""
@@ -151,16 +143,20 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             op = PauliSumOp.from_list([("IZ", 1j)])
             _ = from_ising(op, 0)
 
-    def test_from_ising3(self):
-        """test to_from_ising 3"""
+    def test_pauli_I_Z(self):
+        """test from_ising and to_ising with Pauli I and Z"""
         with self.subTest("I"):
             q_p = from_ising(2 * I)
             self.assertEqual(q_p.get_num_vars(), 1)
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 2)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0])
-            np.testing.assert_array_almost_equal(q_p.objective.quadratic.to_array(), [[0]])
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((2, 2)))
+            self.assertAlmostEqual(offset, 2)
 
         with self.subTest("Z, linear=False"):
             q_p = from_ising(Z)
@@ -168,8 +164,12 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 1)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0])
-            np.testing.assert_array_almost_equal(q_p.objective.quadratic.to_array(), [[-2]])
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[-2]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), Z.to_matrix())
+            self.assertAlmostEqual(offset, 0)
 
         with self.subTest("Z, linear=True"):
             q_p = from_ising(Z, linear=True)
@@ -177,8 +177,12 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 1)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [-2])
-            np.testing.assert_array_almost_equal(q_p.objective.quadratic.to_array(), [[0]])
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [-2])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), Z.to_matrix())
+            self.assertAlmostEqual(offset, 0)
 
         with self.subTest("II"):
             q_p = from_ising(3 * I ^ I)
@@ -186,10 +190,12 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 3)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0, 0])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), np.zeros((4, 4)))
+            self.assertAlmostEqual(offset, 3)
 
         with self.subTest("IZ, linear=False"):
             q_p = from_ising(I ^ Z)
@@ -197,10 +203,12 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 1)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0, 0])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[-2, 0], [0, 0]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[-2, 0], [0, 0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), (I ^ Z).to_matrix())
+            self.assertAlmostEqual(offset, 0)
 
         with self.subTest("IZ, linear=True"):
             q_p = from_ising(I ^ Z, linear=True)
@@ -208,7 +216,9 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
             self.assertEqual(q_p.get_num_linear_constraints(), 0)
             self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
             self.assertAlmostEqual(q_p.objective.constant, 1)
-            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [-2, 0])
-            np.testing.assert_array_almost_equal(
-                q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]]
-            )
+            np.testing.assert_allclose(q_p.objective.linear.to_array(), [-2, 0])
+            np.testing.assert_allclose(q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]])
+
+            op, offset = to_ising(q_p)
+            np.testing.assert_allclose(op.to_matrix(), (I ^ Z).to_matrix())
+            self.assertAlmostEqual(offset, 0)

--- a/test/translators/test_ising.py
+++ b/test/translators/test_ising.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,7 +16,7 @@ from test.optimization_test_case import QiskitOptimizationTestCase
 
 import numpy as np
 
-from qiskit.opflow import PauliSumOp
+from qiskit.opflow import PauliSumOp, I, Z
 from qiskit_optimization.exceptions import QiskitOptimizationError
 from qiskit_optimization.problems import QuadraticProgram
 from qiskit_optimization.translators import from_ising, to_ising
@@ -150,3 +150,65 @@ class TestIsingTranslator(QiskitOptimizationTestCase):
         with self.assertRaises(QiskitOptimizationError):
             op = PauliSumOp.from_list([("IZ", 1j)])
             _ = from_ising(op, 0)
+
+    def test_from_ising3(self):
+        """test to_from_ising 3"""
+        with self.subTest("I"):
+            q_p = from_ising(2 * I)
+            self.assertEqual(q_p.get_num_vars(), 1)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 2)
+            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_array_almost_equal(q_p.objective.quadratic.to_array(), [[0]])
+
+        with self.subTest("Z, linear=False"):
+            q_p = from_ising(Z)
+            self.assertEqual(q_p.get_num_vars(), 1)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 1)
+            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0])
+            np.testing.assert_array_almost_equal(q_p.objective.quadratic.to_array(), [[-2]])
+
+        with self.subTest("Z, linear=True"):
+            q_p = from_ising(Z, linear=True)
+            self.assertEqual(q_p.get_num_vars(), 1)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 1)
+            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [-2])
+            np.testing.assert_array_almost_equal(q_p.objective.quadratic.to_array(), [[0]])
+
+        with self.subTest("II"):
+            q_p = from_ising(3 * I ^ I)
+            self.assertEqual(q_p.get_num_vars(), 2)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 3)
+            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_array_almost_equal(
+                q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]]
+            )
+
+        with self.subTest("IZ, linear=False"):
+            q_p = from_ising(I ^ Z)
+            self.assertEqual(q_p.get_num_vars(), 2)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 1)
+            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [0, 0])
+            np.testing.assert_array_almost_equal(
+                q_p.objective.quadratic.to_array(), [[-2, 0], [0, 0]]
+            )
+
+        with self.subTest("IZ, linear=True"):
+            q_p = from_ising(I ^ Z, linear=True)
+            self.assertEqual(q_p.get_num_vars(), 2)
+            self.assertEqual(q_p.get_num_linear_constraints(), 0)
+            self.assertEqual(q_p.get_num_quadratic_constraints(), 0)
+            self.assertAlmostEqual(q_p.objective.constant, 1)
+            np.testing.assert_array_almost_equal(q_p.objective.linear.to_array(), [-2, 0])
+            np.testing.assert_array_almost_equal(
+                q_p.objective.quadratic.to_array(), [[0, 0], [0, 0]]
+            )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Fixes an issue that `from_ising` raises an error with Pauli I.
- Fixes an issue that `to_ising` returns a wrong operator with an input problem without any variable.

Fixes #354

### Details and comments

Replaced `assert_array_almost_equal` with `assert_allclose` in test_ising.py following [numpy's doc](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_almost_equal.html).
> It is recommended to use one of [assert_allclose](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_allclose.html#numpy.testing.assert_allclose), [assert_array_almost_equal_nulp](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_almost_equal_nulp.html#numpy.testing.assert_array_almost_equal_nulp) or [assert_array_max_ulp](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_max_ulp.html#numpy.testing.assert_array_max_ulp) instead of this function for more consistent floating point comparisons.