### PR TITLE
Fix code example in ``RecursiveMinimumEigenOptimizer``

### DIFF
--- a/qiskit_optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit_optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_optimization/algorithms/recursive_minimum_eigen_optimizer.py
+++ b/qiskit_optimization/algorithms/recursive_minimum_eigen_optimizer.py
@@ -121,21 +121,26 @@ class RecursiveMinimumEigenOptimizer(OptimizationAlgorithm):
     Examples:
         Outline of how to use this class:
 
-    .. code-block::
+    .. code-block:: python
 
         from qiskit.algorithms import QAOA
         from qiskit_optimization.problems import QuadraticProgram
-        from qiskit_optimization.algorithms import RecursiveMinimumEigenOptimizer
+        from qiskit_optimization.algorithms import (
+            MinimumEigenOptimizer, RecursiveMinimumEigenOptimizer
+        )
+
         problem = QuadraticProgram()
         # specify problem here
         # specify minimum eigen solver to be used, e.g., QAOA
         qaoa = QAOA(...)
-        optimizer = RecursiveMinimumEigenOptimizer(qaoa)
+        internal_optimizer = MinimumEigenOptimizer(qaoa)
+
+        optimizer = RecursiveMinimumEigenOptimizer(internal_optimizer)
         result = optimizer.solve(problem)
 
     References:
-        [1]: Bravyi et al. (2019), Obstacles to State Preparation and Variational Optimization
-            from Symmetry Protection. http://arxiv.org/abs/1910.08980.
+        [1] Bravyi et al. (2019), Obstacles to State Preparation and Variational Optimization
+        from Symmetry Protection. `arXiv:1910.08980 <http://arxiv.org/abs/1910.08980>`_
     """
 
     def __init__(


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The code example was passing a ``QAOA`` as ``optimizer``
but this needs to be an ``OptimizationAlgorithm``.

Also, the formatting for the reference was adjusted. Using a colon
starts a new subsection in Sphinx, which we don't want here:

![image](https://user-images.githubusercontent.com/5978796/162147600-ddaf7869-038c-4c42-8eb7-e3806c8c671a.png)


### Details and comments


