### PR TITLE
Load Aer dynamically in unit tests

### DIFF
--- a/test/algorithms/test_grover_optimizer.py
+++ b/test/algorithms/test_grover_optimizer.py
@@ -18,7 +18,6 @@ from test import QiskitOptimizationTestCase
 import numpy as np
 from ddt import data, ddt
 from docplex.mp.model import Model
-import qiskit
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
 from qiskit.algorithms import NumPyMinimumEigensolver
 from qiskit_optimization.algorithms import (
@@ -45,13 +44,16 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
     def setUp(self):
         super().setUp()
         algorithm_globals.random_seed = 1
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         self.sv_simulator = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=921,
             seed_transpiler=200,
         )
         self.qasm_simulator = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             seed_simulator=123,
             seed_transpiler=123,
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Aer is in the process of migrating out of namespaces.
In the meantime, `from qiskit import Aer` emits a deprecation asking to use qiskit_aer which is not ready yet.
Using `qiskit.providers.aer` works fine but it is giving pylint errors when statically loading.

Until qiskit-aer has its own root package qiskit_aer, I am importing Aer dynamically under unit tests to avoid pylint errors.



### Details and comments


