### PR TITLE
Reinstate removal of matplotlib in CI unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.python-version }}
           path: ./ci-artifact-data/*
-      - name: Optimization Unit Tests without cplex/cvxpy/gurobipy under Python ${{ matrix.python-version }}
+      - name: Optimization Unit Tests without cplex/cvxpy/matplotlib/gurobipy under Python ${{ matrix.python-version }}
         env:
           PYTHONWARNINGS: default
         run: |
@@ -214,7 +214,7 @@ jobs:
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
-          pip uninstall -y cplex cvxpy gurobipy
+          pip uninstall -y cplex cvxpy matplotlib gurobipy
           if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ contains(github.event.pull_request.labels.*.name, 'run_slow') }}" == "true" ]; then
               export QISKIT_TESTS="run_slow"
           fi


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
After Terra Qiskit/qiskit-terra#8737 fix, reinstate tests without matplotlib installed.


### Details and comments


