### PR TITLE
Raise an error if `VQE` is given to `MinimumEigenOptimizer`

### DIFF
--- a/qiskit_optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit_optimization/algorithms/minimum_eigen_optimizer.py
@@ -154,8 +154,8 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
         """
         if isinstance(min_eigen_solver, VQE):
             raise TypeError(
-                "MinimumEigenOptimizer does not support VQE but SamplingVQE. "
-                "qiskit.algorithms.minimum_eigensolvers.SamplingVQE may help you."
+                "MinimumEigenOptimizer does not support this VQE. You can use  "
+                "qiskit.algorithms.minimum_eigensolvers.SamplingVQE instead."
             )
         if not isinstance(
             min_eigen_solver,

--- a/qiskit_optimization/algorithms/minimum_eigen_optimizer.py
+++ b/qiskit_optimization/algorithms/minimum_eigen_optimizer.py
@@ -23,6 +23,7 @@ from qiskit.algorithms.minimum_eigensolvers import (
     NumPyMinimumEigensolverResult,
     SamplingMinimumEigensolver,
     SamplingMinimumEigensolverResult,
+    VQE,
 )
 from qiskit.opflow import OperatorBase, PauliOp, PauliSumOp
 
@@ -147,10 +148,26 @@ class MinimumEigenOptimizer(OptimizationAlgorithm):
                 :class:`~qiskit_optimization.converters.QuadraticProgramToQubo` will be used.
 
         Raises:
+            TypeError: If minimum eigensolver has an invalid type.
             TypeError: When one of converters has an invalid type.
             QiskitOptimizationError: When the minimum eigensolver does not return an eigenstate.
         """
-
+        if isinstance(min_eigen_solver, VQE):
+            raise TypeError(
+                "MinimumEigenOptimizer does not support VQE but SamplingVQE. "
+                "qiskit.algorithms.minimum_eigensolvers.SamplingVQE may help you."
+            )
+        if not isinstance(
+            min_eigen_solver,
+            (SamplingMinimumEigensolver, NumPyMinimumEigensolver, LegacyMinimumEigensolver),
+        ):
+            raise TypeError(
+                "MinimumEigenOptimizer supports "
+                "qiskit.algorithms.minimum_eigensolvers.SamplingMinimumEigensolver, "
+                "qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver, and "
+                "qiskit.algorithms.minimum_eigen_solvers.MinimumEigensolver. "
+                f"But {type(min_eigen_solver)} is given."
+            )
         if not min_eigen_solver.supports_aux_operators():
             raise QiskitOptimizationError(
                 "Given MinimumEigensolver does not return the eigenstate "

--- a/test/algorithms/test_min_eigen_optimizer.py
+++ b/test/algorithms/test_min_eigen_optimizer.py
@@ -18,10 +18,10 @@ from test.runtime.fake_vqeruntime import FakeQAOARuntimeProvider, FakeVQERuntime
 
 import numpy as np
 from ddt import data, ddt, unpack
-from qiskit.algorithms.minimum_eigensolvers import QAOA, NumPyMinimumEigensolver, SamplingVQE
+from qiskit.algorithms.minimum_eigensolvers import QAOA, NumPyMinimumEigensolver, SamplingVQE, VQE
 from qiskit.algorithms.optimizers import COBYLA, SPSA
 from qiskit.circuit.library import TwoLocal
-from qiskit.primitives import Sampler
+from qiskit.primitives import Estimator, Sampler
 from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.utils import algorithm_globals
 
@@ -331,6 +331,15 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
         np.testing.assert_array_almost_equal(results.raw_samples[0].x, [0, 1])
         self.assertAlmostEqual(results.raw_samples[0].fval, opt_sol)
         self.assertEqual(results.raw_samples[0].status, success)
+
+    def test_errors(self):
+        """Test for errors"""
+        optimizer = SPSA(maxiter=100)
+        ry_ansatz = TwoLocal(5, "ry", "cz", reps=3, entanglement="full")
+        estimator = Estimator()
+        vqe = VQE(estimator, ry_ansatz, optimizer)
+        with self.assertRaises(TypeError):
+            _ = MinimumEigenOptimizer(vqe)
 
     @data("vqe", "qaoa")
     def test_runtime(self, subroutine):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR has `MinimumEigenOptimizer` raises an error if the new `VQE` is given because `MinimumEigenOptimizer` supports `SamplingVQE` instead.
I added a special error message to suggest `SamplingVQE` if `VQE` is given because it can often happen.


### Details and comments


