### PR TITLE
Update `GroverOptimizer` with Sampler

### DIFF
--- a/qiskit_optimization/algorithms/grover_optimizer.py
+++ b/qiskit_optimization/algorithms/grover_optimizer.py
@@ -368,7 +368,9 @@ class GroverOptimizer(OptimizationAlgorithm):
                 raise QiskitOptimizationError("Sampler job failed.") from exc
             quasi_dist = result.quasi_dists[0]
             raw_prob_dist = {
-                k: v for k, v in quasi_dist.binary_probabilities(qc.num_qubits).items() if v > 1e-6
+                k: v
+                for k, v in quasi_dist.binary_probabilities(qc.num_qubits).items()
+                if v >= self._MIN_PROBABILITY
             }
             prob_dist = {k[::-1]: v for k, v in raw_prob_dist.items()}
             self._circuit_results = {i: v**0.5 for i, v in raw_prob_dist.items()}

--- a/qiskit_optimization/algorithms/grover_optimizer.py
+++ b/qiskit_optimization/algorithms/grover_optimizer.py
@@ -14,33 +14,30 @@
 
 import logging
 import math
-from copy import deepcopy
-from typing import Optional, Dict, Union, List, cast
 import warnings
+from copy import deepcopy
+from typing import Dict, List, Optional, Union, cast
 
 import numpy as np
-
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.algorithms import AmplificationProblem
-from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.algorithms.amplitude_amplifiers.grover import Grover
 from qiskit.circuit.library import QuadraticForm
 from qiskit.primitives import BaseSampler
 from qiskit.providers import Backend
 from qiskit.quantum_info import partial_trace
-from .optimization_algorithm import (
-    OptimizationResultStatus,
-    OptimizationAlgorithm,
-    OptimizationResult,
-    SolutionSample,
-)
-from ..converters.quadratic_program_to_qubo import (
-    QuadraticProgramToQubo,
-    QuadraticProgramConverter,
-)
+from qiskit.utils import QuantumInstance, algorithm_globals
+
+from ..converters.quadratic_program_to_qubo import QuadraticProgramConverter, QuadraticProgramToQubo
 from ..exceptions import QiskitOptimizationError
 from ..problems import Variable
 from ..problems.quadratic_program import QuadraticProgram
+from .optimization_algorithm import (
+    OptimizationAlgorithm,
+    OptimizationResult,
+    OptimizationResultStatus,
+    SolutionSample,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -370,13 +367,11 @@ class GroverOptimizer(OptimizationAlgorithm):
             except Exception as exc:
                 raise QiskitOptimizationError("Sampler job failed.") from exc
             quasi_dist = result.quasi_dists[0]
-            bit_length = (len(quasi_dist) - 1).bit_length()
-            prob_dist = {f"{i:0{bit_length}b}"[::-1]: v for i, v in quasi_dist.items()}
-            self._circuit_results = {
-                f"{i:0{bit_length}b}": v**0.5
-                for i, v in quasi_dist.items()
-                if not np.isclose(v, 0)
+            raw_prob_dist = {
+                k: v for k, v in quasi_dist.binary_probabilities(qc.num_qubits).items() if v > 1e-6
             }
+            prob_dist = {k[::-1]: v for k, v in raw_prob_dist.items()}
+            self._circuit_results = {i: v**0.5 for i, v in raw_prob_dist.items()}
         else:
             result = self._quantum_instance.execute(qc)
             if self._quantum_instance.is_statevector:

--- a/test/algorithms/test_grover_optimizer.py
+++ b/test/algorithms/test_grover_optimizer.py
@@ -20,7 +20,6 @@ from ddt import data, ddt
 from docplex.mp.model import Model
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
 from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
-from qiskit.primitives import Sampler
 from qiskit_optimization.algorithms import (
     GroverOptimizer,
     MinimumEigenOptimizer,
@@ -46,6 +45,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
         super().setUp()
         algorithm_globals.random_seed = 1
         from qiskit_aer import Aer
+        from qiskit_aer.primitives import Sampler
 
         self.sv_simulator = QuantumInstance(
             Aer.get_backend("aer_simulator_statevector"),
@@ -57,6 +57,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
             seed_simulator=123,
             seed_transpiler=123,
         )
+        self.sampler = Sampler(run_options={"seed_simulator": 123})
         self.n_iter = 8
 
     def _prepare_grover_optimizer(
@@ -84,7 +85,7 @@ class TestGroverOptimizer(QiskitOptimizationTestCase):
                 num_value_qubits=num_value_qubits,
                 num_iterations=num_iterations,
                 converters=converters,
-                sampler=Sampler(),
+                sampler=self.sampler,
             )
         return grover_optimizer
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Simplified Sampler code for `GroverOptimizer` by interpreting quasi distribution  with `binary_probabilities` method.

- Introduces `min_probability` 1e-6 same as `OptimizationAlgorithm._eigenvector_to_solutions`. I want to discuss the parameter `min_probability` at #449.
https://github.com/Qiskit/qiskit-optimization/blob/e9751cbc8bd082202a1c017b6264db0af2235e84/qiskit_optimization/algorithms/optimization_algorithm.py#L525
- Uses `AerSampler` instead of the reference Terra `Sampler` because `AerSampler` is much faster than the reference `Sampler` as follows.
- Removed a warning message that users cannot control https://github.com/Qiskit/qiskit-optimization/pull/448#discussion_r1036216409

main
```
> python -m unittest test.algorithms.test_grover_optimizer.TestGroverOptimizer.test_samples_and_raw_samples_3_sampler
(88.55s)
.
----------------------------------------------------------------------
Ran 1 test in 88.545s

OK
```

this PR
```
> python -m unittest test.algorithms.test_grover_optimizer.TestGroverOptimizer.test_samples_and_raw_samples_3_sampler
.
----------------------------------------------------------------------
Ran 1 test in 3.884s

OK
```

### Details and comments


