### PR TITLE
Various docs changes for CI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_design",
     "jupyter_sphinx",
-    "sphinx_autodoc_typehints",
     "reno.sphinxext",
     "sphinx.ext.doctest",
     "nbsphinx",
@@ -114,6 +113,7 @@ nbsphinx_thumbnails = {
     "tutorials/03_minimum_eigen_optimizer": "_static/3_min_eig_opt.png",
     "tutorials/04_grover_optimizer": "_static/4_grover.png",
     "tutorials/05_admm_optimizer": "_static/5_ADMM.png",
+    "**": "_static/no_image.png",
 }
 
 spelling_word_list_filename = "../.pylintdict"
@@ -129,6 +129,12 @@ autosummary_generate_overwrite = False
 # -----------------------------------------------------------------------------
 # Autodoc
 # -----------------------------------------------------------------------------
+# Move type hints from signatures to the parameter descriptions (except in overload cases, where
+# that's not possible).
+autodoc_typehints = "description"
+# Only add type hints from signature to description body if the parameter has documentation.  The
+# return type is always added to the description (if in the signature).
+autodoc_typehints_description_target = "documented_params"
 
 autodoc_default_options = {
     "inherited-members": None,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,10 +6,9 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
 reno>=3.4.0
-Sphinx>=1.8.3,!=3.1.0,!=5.2.0,!=5.2.0.post0
+Sphinx>=5.0
 sphinx-design>=0.2.0
 sphinx-gallery
-sphinx-autodoc-typehints<1.14.0
 sphinxcontrib-spelling
 jupyter-sphinx
 discover

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/requirements-dev.txt
   sphinx-intl
+  jupyter
 commands =
   sphinx-build -W -T --keep-going -b gettext docs/ docs/_build/gettext {posargs}
   sphinx-intl -c docs/conf.py update -p docs/_build/gettext -l en -d docs/locale


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

See Qiskit/qiskit-nature#1109 for more detail.

Basically does the same three things

- Removes dependency on sphinx-autodoc-typehints
- Adds default thumbnail config as that changed in nbsphinx 0.9
- Updates tox.ini gettext section used for translatable strings due to ipykernel not being installed by default now


### Details and comments


