### PR TITLE
Fix ``BackendV2`` support in runtime clients

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -11,6 +11,7 @@ args
 arxiv
 autosummary
 backend
+backends
 barkoutsos
 benchmarking
 bitstring

--- a/qiskit_optimization/runtime/vqe_client.py
+++ b/qiskit_optimization/runtime/vqe_client.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,7 +20,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.providers import Provider
-from qiskit.providers.backend import Backend
+from qiskit.providers.backend import Backend, BackendV2
 from qiskit.algorithms import MinimumEigensolver, MinimumEigensolverResult, VQEResult
 from qiskit.algorithms.optimizers import Optimizer, SPSA
 from qiskit.opflow import OperatorBase, PauliSumOp
@@ -297,7 +297,11 @@ class VQEClient(MinimumEigensolver):
         inputs = self.program_inputs(operator, aux_operators)
 
         # define runtime options
-        options = {"backend_name": self.backend.name()}
+        options = {
+            "backend_name": self.backend.name
+            if isinstance(self.backend, BackendV2)
+            else self.backend.name()
+        }
 
         # send job to runtime and return result
         job = self._send_job(inputs, options)

--- a/releasenotes/notes/runtimeclient-v2compat-c5b5541401cc6405.yaml
+++ b/releasenotes/notes/runtimeclient-v2compat-c5b5541401cc6405.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix support of ``BackendV2`` in the :class:`.VQEClient`. Previously, backends instantiated
+    with the ``IBMProvider`` failed since they return backends of type ``BackendV2``, which
+    were not correctly supported in the VQE client. Backends instantiated with the ``IBMQ``
+    provider continue to work as before.
+

--- a/test/algorithms/test_min_eigen_optimizer.py
+++ b/test/algorithms/test_min_eigen_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2022.
+# (C) Copyright IBM 2018, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -23,6 +23,7 @@ from qiskit.algorithms.optimizers import COBYLA, SPSA
 from qiskit.circuit.library import TwoLocal
 from qiskit.primitives import Estimator, Sampler
 from qiskit.providers.basicaer import QasmSimulatorPy
+from qiskit.providers.fake_provider import FakeArmonk, FakeArmonkV2
 from qiskit.utils import algorithm_globals
 
 import qiskit_optimization.optionals as _optionals
@@ -368,6 +369,20 @@ class TestMinEigenOptimizer(QiskitOptimizationTestCase):
                 provider=FakeQAOARuntimeProvider(),
             )
 
+        opt = MinimumEigenOptimizer(solver)
+        result = opt.solve(self.op_ordering)
+        self.assertIsInstance(result, MinimumEigenOptimizationResult)
+
+    @data(FakeArmonk, FakeArmonkV2)
+    def test_runtime_backend_versions(self, backend_cls):
+        """Test the runtime client with a V1 and a V2 backend."""
+        optimizer = SPSA(maxiter=1, learning_rate=0.1, perturbation=0.1)
+        backend = backend_cls()
+        provider = FakeVQERuntimeProvider()
+        ansatz = TwoLocal(1, "ry", reps=0)
+        initial_point = np.array([1])
+
+        solver = VQEClient(ansatz, optimizer, initial_point, provider, backend)
         opt = MinimumEigenOptimizer(solver)
         result = opt.solve(self.op_ordering)
         self.assertIsInstance(result, MinimumEigenOptimizationResult)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds support for ``BackendV2`` backends in the runtime clients.

### Details and comments

This is the analogous PR to Qiskit/qiskit-nature#1116.
