### PR TITLE
Tag cell with nbsphinx-thumbnail

### DIFF
--- a/docs/tutorials/06_examples_max_cut_and_tsp.ipynb
+++ b/docs/tutorials/06_examples_max_cut_and_tsp.ipynb
@@ -927,7 +927,11 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1011,8 +1015,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/07_examples_vehicle_routing.ipynb
+++ b/docs/tutorials/07_examples_vehicle_routing.ipynb
@@ -711,7 +711,11 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -807,8 +811,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/08_cvar_optimization.ipynb
+++ b/docs/tutorials/08_cvar_optimization.ipynb
@@ -243,7 +243,11 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -350,8 +354,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/09_application_classes.ipynb
+++ b/docs/tutorials/09_application_classes.ipynb
@@ -220,7 +220,11 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -566,8 +570,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/10_warm_start_qaoa.ipynb
+++ b/docs/tutorials/10_warm_start_qaoa.ipynb
@@ -424,7 +424,11 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "pacific-destiny",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -712,8 +716,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/12_qaoa_runtime.ipynb
+++ b/docs/tutorials/12_qaoa_runtime.ipynb
@@ -322,7 +322,11 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "73a06065",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -638,8 +642,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   },
   "nbsphinx": {
    "execute": "never"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After update the conf.py, like the other repos, to list the default thumbnail image. since with nbsphinx 0.9 it no longer recognizes the older way of doing that with the png file, some tiles "lost" their images, as below. Only the 5 with explicit images in the conf.py show up

![image](https://user-images.githubusercontent.com/40241007/230946030-f6efa61c-2ac4-4efa-b606-2a6815fed4a4.png)

This is how it looked before without the conf/py default thumbnail change where the tile that should have the sphere image does not.

![image](https://user-images.githubusercontent.com/40241007/230946257-d922a024-6f8a-42e2-b661-4184cb1e8865.png)

### Details and comments

It seems that the last image in the notebook was automatically selected how things were before. I added an explicit `nbsphinx-thumbnail` tag to the respective cell (as we have done in other repos which is why I did not see that there). I also selected a better image, I think, for the qaoa runtime. This is how it looks now.

![image](https://user-images.githubusercontent.com/40241007/230946892-69328afc-ecee-4a98-96a4-8d2a3409fa77.png)




