### PR TITLE
Deprecate `qiskit_optimization.runtime` module

### DIFF
--- a/docs/tutorials/12_qaoa_runtime.ipynb
+++ b/docs/tutorials/12_qaoa_runtime.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     ".. warning::\n",
-    "  The `VQEClient` and `QAOAClient` discussed in this tutorial is **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out these guides [here (VQE)](https://qisk.it/algo_migration#vqe) and [here (QAOA)](https://qisk.it/algo_migration#qaoa)."
+    "  The `VQEClient` and `QAOAClient` discussed in this tutorial are **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` and `QAOA` algorithms respectively with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out these guides [here (VQE)](https://qisk.it/algo_migration#vqe) and [here (QAOA)](https://qisk.it/algo_migration#qaoa)."
    ]
   },
   {

--- a/docs/tutorials/12_qaoa_runtime.ipynb
+++ b/docs/tutorials/12_qaoa_runtime.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     ".. warning::\n",
-    "  The `VQEClient` and `QAOAClient` discussed in this tutorial is **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out this guide [here](https://qisk.it/algo_migration#vqe) and [here](https://qisk.it/algo_migration#qaoa)."
+    "  The `VQEClient` and `QAOAClient` discussed in this tutorial is **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out these guides [here (VQE)](https://qisk.it/algo_migration#vqe) and [here (QAOA)](https://qisk.it/algo_migration#qaoa)."
    ]
   },
   {

--- a/docs/tutorials/12_qaoa_runtime.ipynb
+++ b/docs/tutorials/12_qaoa_runtime.ipynb
@@ -5,10 +5,24 @@
    "id": "d9a5a73c",
    "metadata": {},
    "source": [
-    "# QAOA Runtime\n",
-    "\n",
-    "The Qiskit runtime is an execution model that permits us to run an entire program on the backend side. Here, we discuss how to run the QAOA algorithm in the Qiskit runtime. We will discuss several of the features that this first version of the QAOA Runtime makes available.\n",
-    "\n"
+    "# QAOA Runtime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d492e9c3",
+   "metadata": {},
+   "source": [
+    ".. warning::\n",
+    "  The `VQEClient` and `QAOAClient` discussed in this tutorial is **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out this guide [here](https://qisk.it/algo_migration#vqe) and [here](https://qisk.it/algo_migration#qaoa)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb8d128b",
+   "metadata": {},
+   "source": [
+    "The Qiskit runtime is an execution model that permits us to run an entire program on the backend side. Here, we discuss how to run the QAOA algorithm in the Qiskit runtime. We will discuss several of the features that this first version of the QAOA Runtime makes available."
    ]
   },
   {
@@ -643,7 +657,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -657,7 +671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.6"
   },
   "nbsphinx": {
    "execute": "never"

--- a/docs/tutorials/12_qaoa_runtime.ipynb
+++ b/docs/tutorials/12_qaoa_runtime.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     ".. warning::\n",
-    "  The `VQEClient` and `QAOAClient` discussed in this tutorial are **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` and `QAOA` algorithms respectively with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out these guides [here (VQE)](https://qisk.it/algo_migration#vqe) and [here (QAOA)](https://qisk.it/algo_migration#qaoa)."
+    "  The `VQEClient` and `QAOAClient` discussed in this tutorial are **DEPRECATED** as of version 0.6 of Qiskit Optimization and will be removed no sooner than 3 months after the release. Instead you should use the new primitives based `SamplingVQE` and `QAOA` algorithms respectively with the Qiskit IBM Runtime Sampler primitive. For more details on how to migrate check out these guides <https://qisk.it/algo_migration#vqe> and <https://qisk.it/algo_migration#qaoa>."
    ]
   },
   {

--- a/qiskit_optimization/runtime/__init__.py
+++ b/qiskit_optimization/runtime/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_optimization/runtime/__init__.py
+++ b/qiskit_optimization/runtime/__init__.py
@@ -11,10 +11,16 @@
 # that they have been altered from the originals.
 
 """
-Qiskit Optimization Runtime (:mod:`qiskit_optimization.runtime`)
-================================================================
+DEPRECATED Qiskit Optimization Runtime (:mod:`qiskit_optimization.runtime`)
+===========================================================================
 
 .. currentmodule:: qiskit_optimization.runtime
+
+.. warning::
+    This entire module is deprecated as of version 0.6.0 and will be removed no sooner than 3 months
+    after the release. Instead you should update your code to use the Qiskit Runtime Primitives. For
+    more details on how to migrate check out this guide, here: https://qisk.it/algo_migration#vqe
+    and https://qisk.it/algo_migration#qaoa !
 
 Programs that embed Qiskit Runtime in the algorithmic interfaces and facilitate usage of
 algorithms and scripts in the cloud.
@@ -29,8 +35,8 @@ algorithms and scripts in the cloud.
 
 """
 
-from .vqe_client import VQEClient, VQERuntimeResult
 from .qaoa_client import QAOAClient
+from .vqe_client import VQEClient, VQERuntimeResult
 
 __all__ = [
     "VQEClient",

--- a/qiskit_optimization/runtime/qaoa_client.py
+++ b/qiskit_optimization/runtime/qaoa_client.py
@@ -102,9 +102,9 @@ class QAOAClient(VQEClient):
         warn_deprecated(
             "0.6.0",
             DeprecatedType.CLASS,
-            "VQEClient",
+            "QAOAClient",
             additional_msg=(
-                ". Instead you should use the new primitives based SamplingVQE with the Qiskit IBM "
+                ". Instead you should use the new primitives based QAOA with the Qiskit IBM "
                 "Runtime Sampler primitive. For more details on how to migrate check out this guide, "
                 "here: https://qisk.it/algo_migration#qaoa"
             ),

--- a/qiskit_optimization/runtime/qaoa_client.py
+++ b/qiskit_optimization/runtime/qaoa_client.py
@@ -13,21 +13,23 @@
 """The Qiskit Optimization QAOA Quantum Program."""
 
 
-from typing import List, Callable, Optional, Any, Dict, Union
-import numpy as np
+from typing import Any, Callable, Dict, List, Optional, Union
 
+import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.algorithms.optimizers import Optimizer
 from qiskit.opflow import OperatorBase
 from qiskit.providers import Provider
 from qiskit.providers.backend import Backend
 
+from qiskit_optimization.deprecation import DeprecatedType, warn_deprecated
 from qiskit_optimization.exceptions import QiskitOptimizationError
+
 from .vqe_client import VQEClient
 
 
 class QAOAClient(VQEClient):
-    """The Qiskit Optimization QAOA Runtime Client."""
+    """DEPRECATED The Qiskit Optimization QAOA Runtime Client."""
 
     def __init__(
         self,
@@ -97,6 +99,16 @@ class QAOAClient(VQEClient):
             QiskitOptimizationError: if optimization_level is not None and use_swap_strategies
                 is True.
         """
+        warn_deprecated(
+            "0.6.0",
+            DeprecatedType.CLASS,
+            "VQEClient",
+            additional_msg=(
+                ". Instead you should use the new primitives based SamplingVQE with the Qiskit IBM "
+                "Runtime Sampler primitive. For more details on how to migrate check out this guide, "
+                "here: https://qisk.it/algo_migration#qaoa"
+            ),
+        )
         if reps < 1:
             raise QiskitOptimizationError(f"reps must be greater than 0, received {reps}.")
 

--- a/qiskit_optimization/runtime/qaoa_client.py
+++ b/qiskit_optimization/runtime/qaoa_client.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_optimization/runtime/vqe_client.py
+++ b/qiskit_optimization/runtime/vqe_client.py
@@ -13,22 +13,24 @@
 """The Qiskit Optimization VQE Runtime Client."""
 
 
-from typing import List, Callable, Optional, Any, Dict, Union
 import warnings
-import numpy as np
+from typing import Any, Callable, Dict, List, Optional, Union
 
+import numpy as np
 from qiskit import QuantumCircuit
+from qiskit.algorithms import MinimumEigensolver, MinimumEigensolverResult, VQEResult
+from qiskit.algorithms.optimizers import SPSA, Optimizer
 from qiskit.exceptions import QiskitError
+from qiskit.opflow import OperatorBase, PauliSumOp
 from qiskit.providers import Provider
 from qiskit.providers.backend import Backend, BackendV2
-from qiskit.algorithms import MinimumEigensolver, MinimumEigensolverResult, VQEResult
-from qiskit.algorithms.optimizers import Optimizer, SPSA
-from qiskit.opflow import OperatorBase, PauliSumOp
 from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_optimization.deprecation import DeprecatedType, warn_deprecated
 
 
 class VQEClient(MinimumEigensolver):
-    """The Qiskit Optimization VQE Runtime Client to call the VQE runtime as a MinimumEigensolver.
+    """DEPRECATED The Qiskit Optimization VQE Runtime Client.
 
     This program is equivalent to the ``VQEClient`` in Qiskit Nature, but here also serves as
     basis for the Qiskit Optimization's ``QAOAClient``.
@@ -68,6 +70,16 @@ class VQEClient(MinimumEigensolver):
             store_intermediate: Whether or not to store intermediate values of the optimization
                 steps. Per default False.
         """
+        warn_deprecated(
+            "0.6.0",
+            DeprecatedType.CLASS,
+            "VQEClient",
+            additional_msg=(
+                ". Instead you should use the new primitives based SamplingVQE with the Qiskit IBM "
+                "Runtime Sampler primitive. For more details on how to migrate check out this guide, "
+                "here: https://qisk.it/algo_migration#vqe"
+            ),
+        )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             super().__init__()
@@ -330,13 +342,14 @@ class VQEClient(MinimumEigensolver):
 
 
 class VQERuntimeResult(VQEResult):
-    """The VQEClient result object.
+    """DEPRECATED The VQEClient result object.
 
     This result objects contains the same as the VQEResult and additionally the history
     of the optimizer, containing information such as the function and parameter values per step.
     """
 
     def __init__(self) -> None:
+        warn_deprecated("0.6.0", DeprecatedType.CLASS, "VQERuntimeResult")
         super().__init__()
         self._job_id = None  # type: str
         self._optimizer_history = None  # type: Dict[str, Any]

--- a/releasenotes/notes/deprecate-vqe-client-de93fff8c4645802.yaml
+++ b/releasenotes/notes/deprecate-vqe-client-de93fff8c4645802.yaml
@@ -3,5 +3,5 @@ deprecations:
   - |
     The :class:`.VQEClient`, :class:`.QAOAClient`, and :class:`.VQERuntimeResult`
     are now deprecated. Instead, users should migrate their code to use the Qiskit
-    Runtime Primitives. A guide on how to use this can be found
-    `here <https://qisk.it/algo_migration#vqe>`_ and `here <https://qisk.it/algo_migration#qaoa>`_.
+    Runtime Primitives. Guides on how to use this can be found
+    `here (VQE) <https://qisk.it/algo_migration#vqe>`_ and `here (QAOA) <https://qisk.it/algo_migration#qaoa>`_.

--- a/releasenotes/notes/deprecate-vqe-client-de93fff8c4645802.yaml
+++ b/releasenotes/notes/deprecate-vqe-client-de93fff8c4645802.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    The :class:`.VQEClient`, :class:`.QAOAClient`, and :class:`.VQERuntimeResult`
+    are now deprecated. Instead, users should migrate their code to use the Qiskit
+    Runtime Primitives. A guide on how to use this can be found
+    `here <https://qisk.it/algo_migration#vqe>`_ and `here <https://qisk.it/algo_migration#qaoa>`_.

--- a/test/runtime/test_qaoaclient.py
+++ b/test/runtime/test_qaoaclient.py
@@ -1,0 +1,64 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the QAOA client."""
+
+import unittest
+import warnings
+from test import QiskitOptimizationTestCase
+
+import numpy as np
+from ddt import data, ddt
+from qiskit.algorithms.optimizers import COBYLA
+from qiskit.opflow import I, Z
+from qiskit.providers.basicaer import QasmSimulatorPy
+
+from qiskit_optimization.runtime import QAOAClient, VQERuntimeResult
+
+from .fake_vqeruntime import FakeQAOARuntimeProvider
+
+
+@ddt
+class TestQAOAClient(QiskitOptimizationTestCase):
+    """Test the QAOA client."""
+
+    def setUp(self):
+        super().setUp()
+        self.provider = FakeQAOARuntimeProvider()
+
+    @data(
+        {"name": "SPSA", "maxiter": 100},
+        COBYLA(),
+    )
+    def test_standard_case(self, optimizer):
+        """Test a standard use case."""
+        reps = 2
+        initial_point = np.random.RandomState(42).random(2 * reps)
+        backend = QasmSimulatorPy()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            operator = Z ^ I ^ Z
+            qaoa = QAOAClient(
+                optimizer=optimizer,
+                reps=reps,
+                initial_point=initial_point,
+                backend=backend,
+                provider=self.provider,
+            )
+            result = qaoa.compute_minimum_eigenvalue(operator)
+
+        self.assertIsInstance(result, VQERuntimeResult)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_qaoaclient.py
+++ b/test/runtime/test_qaoaclient.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/runtime/test_vqeclient.py
+++ b/test/runtime/test_vqeclient.py
@@ -1,0 +1,65 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the VQE client."""
+
+import unittest
+import warnings
+from test import QiskitOptimizationTestCase
+
+import numpy as np
+from ddt import data, ddt
+from qiskit.algorithms.optimizers import COBYLA
+from qiskit.circuit.library import RealAmplitudes
+from qiskit.opflow import I, Z
+from qiskit.providers.basicaer import QasmSimulatorPy
+
+from qiskit_optimization.runtime import VQEClient, VQERuntimeResult
+
+from .fake_vqeruntime import FakeVQERuntimeProvider
+
+
+@ddt
+class TestVQEClient(QiskitOptimizationTestCase):
+    """Test the VQE client."""
+
+    def setUp(self):
+        super().setUp()
+        self.provider = FakeVQERuntimeProvider()
+
+    @data(
+        {"name": "SPSA", "maxiter": 100},
+        COBYLA(),
+    )
+    def test_standard_case(self, optimizer):
+        """Test a standard use case."""
+        circuit = RealAmplitudes(3)
+        initial_point = np.random.RandomState(42).random(circuit.num_parameters)
+        backend = QasmSimulatorPy()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            operator = Z ^ I ^ Z
+            vqe = VQEClient(
+                ansatz=circuit,
+                optimizer=optimizer,
+                initial_point=initial_point,
+                backend=backend,
+                provider=self.provider,
+            )
+            result = vqe.compute_minimum_eigenvalue(operator)
+
+        self.assertIsInstance(result, VQERuntimeResult)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_vqeclient.py
+++ b/test/runtime/test_vqeclient.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`VQEClient` and `QAOAClient` are superseded by the Qiskit Runtime Primitives.
This PR follows https://github.com/Qiskit/qiskit-nature/pull/1124.

I noticed that #441 accidentally removed unit tests of `VQEClient` and `QAOAClient`. So, I restored them.

Fixes #494

### Details and comments


