### PR TITLE
Terra main vs stable install switch

### DIFF
--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -77,6 +77,10 @@ runs:
           fi
         else
           echo 'Install Terra from Stable'
+          if [ "${{ inputs.os }}" == "windows-2019" ]; then
+            source "$CONDA/etc/profile.d/conda.sh"
+            conda activate scsenv
+          fi
           pip install -U qiskit-terra
         fi
       shell: bash

--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -19,6 +19,9 @@ inputs:
   python-version:
     description: 'Python version'
     required: true
+  terra-main:
+    description: 'Use Terra main'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -38,38 +41,43 @@ runs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.15
       run: |
-        echo 'Install Terra from Main'
-        if [ "${{ inputs.os }}" == "windows-2019" ]; then
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate scsenv
-        fi
-        BASE_DIR=terra-cache
-        build_from_main=true
-        cache_hit=${{ steps.terra-cache.outputs.cache-hit }}
-        echo "cache hit: ${cache_hit}"
-        if [ "$cache_hit" == "true" ]; then
-          pip_result=0
-          pushd "${BASE_DIR}"
-          python -m pip install *.whl && pip_result=$? || pip_result=$?
-          popd
-          if [ $pip_result == 0 ]; then
-            build_from_main=false
+        if [ "${{ inputs.terra-main }}" == "true" ]; then
+          echo 'Install Terra from Main'
+          if [ "${{ inputs.os }}" == "windows-2019" ]; then
+            source "$CONDA/etc/profile.d/conda.sh"
+            conda activate scsenv
+          fi
+          BASE_DIR=terra-cache
+          build_from_main=true
+          cache_hit=${{ steps.terra-cache.outputs.cache-hit }}
+          echo "cache hit: ${cache_hit}"
+          if [ "$cache_hit" == "true" ]; then
+            pip_result=0
+            pushd "${BASE_DIR}"
+            python -m pip install *.whl && pip_result=$? || pip_result=$?
+            popd
+            if [ $pip_result == 0 ]; then
+              build_from_main=false
+            fi
+          else
+            mkdir -p ${BASE_DIR}
+          fi
+          if [ "$build_from_main" == "true" ]; then
+            echo 'Create wheel file from main'
+            pip install -U wheel setuptools_rust
+            git clone --depth 1 --branch main https://github.com/Qiskit/qiskit-terra.git /tmp/qiskit-terra
+            pushd /tmp/qiskit-terra
+            python setup.py bdist_wheel
+            popd
+            cp -rf /tmp/qiskit-terra/dist/*.whl "${BASE_DIR}"
+            pushd "${BASE_DIR}"
+            python -m pip install *.whl
+            popd
+            pip uninstall -y setuptools_rust
           fi
         else
-          mkdir -p ${BASE_DIR}
-        fi
-        if [ "$build_from_main" == "true" ]; then
-          echo 'Create wheel file from main'
-          pip install -U wheel setuptools_rust
-          git clone --depth 1 --branch main https://github.com/Qiskit/qiskit-terra.git /tmp/qiskit-terra
-          pushd /tmp/qiskit-terra
-          python setup.py bdist_wheel
-          popd
-          cp -rf /tmp/qiskit-terra/dist/*.whl "${BASE_DIR}"
-          pushd "${BASE_DIR}"
-          python -m pip install *.whl
-          popd
-          pip uninstall -y setuptools_rust
+          echo 'Install Terra from Stable'
+          pip install -U qiskit-terra
         fi
       shell: bash
     - name: Install stable Aer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+          terra-main: "false"
         if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
       - uses: ./.github/actions/install-optimization
         with:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As Terra main has dropped Python 3.7 support (and with it CI here - see last nights scheduled build - using Terra main fails against 3.7) this enables a switch of the install between main or stable and it's set at present not to use main (i,e, pip install latest stable)

See Qiskit/qiskit-nature#1159 for similar

### Details and comments


