### PR TITLE
Turn off CI for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   Checks:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -109,6 +110,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
   Optimization:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -214,6 +216,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
   Tutorials:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -293,6 +296,7 @@ jobs:
           path: docs/_build/html/artifacts/tutorials.tar.gz
         if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
   Deprecation_Messages_and_Coverage:
+    if: github.repository_owner == 'Qiskit'
     needs: [Checks, Optimization, Tutorials]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Most people agree that GitHub made a mistake by having forks run CI both on the fork and in the upstream repository. It wastes computing resources (which has a real environmental cost!).

If people really want to run CI in their fork, they can always modify their fork's config to revert this change.
