### PR TITLE
Update mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,12 @@
 queue_rules:
   - name: automerge
     conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.7)
+      - check-success=Deprecation_Messages_and_Coverage (3.8)
 
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.7)
+      - check-success=Deprecation_Messages_and_Coverage (3.8)
       - "#approved-reviews-by>=1"
       - label=automerge
       - label!=on hold


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#497 updated the `Deprecation_Messages_and_Coverage` job of the main workflow to use Python 3.8 (was 3.7 before). The outcome of this is used by mergify for its readiness check. This updates the mergify config to match so automerge label will have an effect again.

This PR likely needs to be manually merged though since its changing the config.

### Details and comments


