### PR TITLE
Improve docs

### DIFF
--- a/docs/_templates/autosummary/class_no_inherited_members.rst
+++ b/docs/_templates/autosummary/class_no_inherited_members.rst
@@ -21,9 +21,11 @@
    .. autosummary::
       :toctree: ../stubs/
    {% for item in all_attributes %}
-      {%- if not item.startswith('_') %}
-          ~{{ name }}.{{ item }}
-      {%- endif -%}
+      {%- if item not in inherited_members %}
+        {%- if not item.startswith('_') %}
+            ~{{ name }}.{{ item }}
+        {%- endif -%}
+      {%- endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}
@@ -36,9 +38,11 @@
    .. autosummary::
       :toctree: ../stubs/
    {% for item in all_methods %}
-      {%- if not item.startswith('_') %}
-          ~{{ name }}.{{ item }}
-      {%- endif -%}
+      {%- if item not in inherited_members %}
+        {%- if not item.startswith('_') %}
+            ~{{ name }}.{{ item }}
+        {%- endif -%}
+      {%- endif %}
    {%- endfor %}
 
    {% endif %}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This is similar to Qiskit/qiskit-machine-learning#635 (and the equivalent done in Nature).

Basically it alters the class template to show inherited methods so that this is now default. I debated, as it's not needed here, at least for now, but I also added the original class template, for consistency with the other repos, as class_no_inherited_methods (named same as qiskit-terra) so that  this template can be used explicitly for autosummary where we do not want inherited methods (in the other app repos this is used for circuit.library circuits, such as UCC, RawFeatureVector). 

### Details and comments


