### PR TITLE
Fixes in ADMMOptimizer

### DIFF
--- a/qiskit_optimization/algorithms/admm_optimizer.py
+++ b/qiskit_optimization/algorithms/admm_optimizer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -369,7 +369,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
             self._state.x0_saved.append(self._state.x0)
             self._state.u_saved.append(self._state.u)
             self._state.z_saved.append(self._state.z)
-            self._state.z_saved.append(self._state.y)
+            self._state.y_saved.append(self._state.y)
 
             self._update_rho(residual, dual_residual)
 
@@ -777,7 +777,7 @@ class ADMMOptimizer(OptimizationAlgorithm):
             if primal_residual > self._params.mu_res * dual_residual:
                 self._state.rho = self._params.tau_incr * self._state.rho
             elif dual_residual > self._params.mu_res * primal_residual:
-                self._state.rho = self._params.tau_decr * self._state.rho
+                self._state.rho = self._state.rho / self._params.tau_decr
 
     def _get_constraint_residual(self) -> float:
         """Compute violation of the constraints of the original problem, as:

--- a/releasenotes/notes/fix-admm-02d70ff90df962eb.yaml
+++ b/releasenotes/notes/fix-admm-02d70ff90df962eb.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed incorrect ``rho`` update when ``vary_rho`` is set to ``UPDATE_RHO_BY_RESIDUALS``
+    in :class:`~qiskit_optimization.algorithms.ADMMOptimizer`.
+  - |
+    Fixed incorrect population of ``y_saved`` in :class:`~qiskit_optimization.algorithms.ADMMState`.

--- a/test/algorithms/test_admm.py
+++ b/test/algorithms/test_admm.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,6 +13,8 @@
 """Tests of the ADMM algorithm."""
 from test import QiskitOptimizationTestCase
 
+from ddt import ddt, data
+
 import numpy as np
 from docplex.mp.model import Model
 from qiskit_optimization.algorithms import CobylaOptimizer
@@ -21,10 +23,13 @@ from qiskit_optimization.algorithms.admm_optimizer import (
     ADMMParameters,
     ADMMOptimizationResult,
     ADMMState,
+    UPDATE_RHO_BY_RESIDUALS,
+    UPDATE_RHO_BY_TEN_PERCENT,
 )
 from qiskit_optimization.translators import from_docplex_mp
 
 
+@ddt
 class TestADMMOptimizer(QiskitOptimizationTestCase):
     """ADMM Optimizer Tests"""
 
@@ -55,7 +60,8 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         self.assertEqual(solution.status, solution.samples[0].status)
         self.assertAlmostEqual(solution.samples[0].probability, 1.0)
 
-    def test_admm_ex4(self):
+    @data(UPDATE_RHO_BY_TEN_PERCENT, UPDATE_RHO_BY_RESIDUALS)
+    def test_admm_ex4(self, update_rho_strategy):
         """Example 4 as a unit test. Example 4 is reported in:
         Gambella, C., & Simonetto, A. (2020).
         Multi-block ADMM Heuristics for Mixed-Binary Optimization on Classical
@@ -77,7 +83,12 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         op = from_docplex_mp(mdl)
 
         admm_params = ADMMParameters(
-            rho_initial=1001, beta=1000, factor_c=900, maxiter=100, three_block=False
+            vary_rho=update_rho_strategy,
+            rho_initial=1001,
+            beta=1000,
+            factor_c=900,
+            maxiter=100,
+            three_block=False,
         )
 
         solver = ADMMOptimizer(params=admm_params)
@@ -127,7 +138,8 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         self.assertIsNotNone(solution.state)
         self.assertIsInstance(solution.state, ADMMState)
 
-    def test_admm_ex5(self):
+    @data(UPDATE_RHO_BY_TEN_PERCENT, UPDATE_RHO_BY_RESIDUALS)
+    def test_admm_ex5(self, update_rho_strategy):
         """Example 5 as a unit test. Example 5 is reported in:
         Gambella, C., & Simonetto, A. (2020).
         Multi-block ADMM Heuristics for Mixed-Binary Optimization on Classical
@@ -148,7 +160,12 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         op = from_docplex_mp(mdl)
 
         admm_params = ADMMParameters(
-            rho_initial=1001, beta=1000, factor_c=900, maxiter=100, three_block=False
+            vary_rho=update_rho_strategy,
+            rho_initial=1001,
+            beta=1000,
+            factor_c=900,
+            maxiter=100,
+            three_block=False,
         )
 
         solver = ADMMOptimizer(params=admm_params)
@@ -200,7 +217,8 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         self.assertIsNotNone(solution.state)
         self.assertIsInstance(solution.state, ADMMState)
 
-    def test_admm_ex6(self):
+    @data(UPDATE_RHO_BY_TEN_PERCENT, UPDATE_RHO_BY_RESIDUALS)
+    def test_admm_ex6(self, update_rho_strategy):
         """Example 6 as a unit test. Example 6 is reported in:
         Gambella, C., & Simonetto, A. (2020).
         Multi-block ADMM Heuristics for Mixed-Binary Optimization on Classical
@@ -222,6 +240,7 @@ class TestADMMOptimizer(QiskitOptimizationTestCase):
         op = from_docplex_mp(mdl)
 
         admm_params = ADMMParameters(
+            vary_rho=update_rho_strategy,
             rho_initial=1001,
             beta=1000,
             factor_c=900,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR introduces two fixes in ADMMOptimizer:
- Fixed incorrect `rho` update when `vary_rho` is set to `UPDATE_RHO_BY_RESIDUALS` in the optimizer.
- Fixed incorrect population of `y_saved` in `ADMMState`.


