### PR TITLE
Add project urls to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,10 @@ setuptools.setup(
         "matplotlib": ["matplotlib"],
         "gurobi": ["gurobipy"],
     },
+    project_urls={
+        "Bug Tracker": "https://github.com/Qiskit/qiskit-optimization/issues",
+        "Documentation": "https://qiskit.org/ecosystem/optimization/",
+        "Source Code": "https://github.com/Qiskit/qiskit-optimization",
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds project urls to setup so that PyPI project page has more than just a `Homepage` url. This adds additional project urls comparable to qiskit-terra i.e. `Bug Tracker`, `Documentation` and `Source Code`.


### Details and comments


